### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,87 @@
+---
+name: Bug report
+about: Report a reproducible software, simulation, navigation, or docking issue
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+# Bug report
+
+## Summary
+
+Briefly describe the problem.
+
+---
+
+## Affected area
+
+Select all that apply:
+
+- [ ] ROS 2 workspace
+- [ ] Robot description
+- [ ] Gazebo / Gazebo Sim
+- [ ] Nav2
+- [ ] Autodocking
+- [ ] Planned bringup package
+- [ ] Planned control package
+- [ ] Planned drivers package
+- [ ] Planned perception package
+- [ ] Documentation
+- [ ] Other
+
+---
+
+## Steps to reproduce
+
+```bash
+# Paste exact commands here
+```
+
+---
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+---
+
+## Actual behavior
+
+Describe what actually happened.
+
+---
+
+## Logs or screenshots
+
+Paste:
+
+- terminal output
+- screenshots
+- RViz screenshots
+- Gazebo screenshots
+- videos
+
+if relevant.
+
+---
+
+## Environment
+
+- OS:
+- ROS 2 distribution:
+- Gazebo / Gazebo Sim version:
+- Branch or commit:
+- Running in Codespaces, local machine, or robot computer:
+
+---
+
+## Safety impact
+
+Does this issue affect real robot movement or safety?
+
+- [ ] No
+- [ ] Yes
+- [ ] Unknown
+
+If yes or unknown, explain the possible risk.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,101 @@
+---
+name: Feature request
+about: Suggest a new feature, improvement, or robotics capability
+title: "[Feature]: "
+labels: enhancement
+assignees: ""
+---
+
+# Feature request
+
+## Summary
+
+Briefly describe the requested feature.
+
+---
+
+## Motivation
+
+Why is this feature useful?
+
+Examples:
+
+- improve simulation workflow
+- improve docking reliability
+- support hardware integration
+- improve Nav2 integration
+- improve contributor workflow
+
+---
+
+## Affected area
+
+Select all that apply:
+
+- [ ] ROS 2 workspace
+- [ ] Robot description
+- [ ] Gazebo / Gazebo Sim
+- [ ] Nav2
+- [ ] Autodocking
+- [ ] Planned bringup package
+- [ ] Planned control package
+- [ ] Planned drivers package
+- [ ] Planned perception package
+- [ ] Documentation
+- [ ] Tooling
+- [ ] CI/CD
+- [ ] Other
+
+---
+
+## Proposed solution
+
+Describe how this could be implemented.
+
+---
+
+## Alternatives considered
+
+Describe alternative approaches if any.
+
+---
+
+## Simulation or hardware impact
+
+Does this feature affect:
+
+- [ ] Simulation only
+- [ ] Real robot behavior
+- [ ] Both simulation and real robot
+- [ ] Unknown
+
+Explain the expected impact.
+
+---
+
+## Dependencies or related packages
+
+List affected packages or dependencies if known.
+
+Example:
+
+```text
+openamrobot_nav2
+openamrobot_docking
+openamrobot_gazebo
+```
+
+---
+
+## Additional context
+
+Add:
+
+- diagrams
+- references
+- screenshots
+- links
+- videos
+- architecture notes
+
+if useful.

--- a/.github/ISSUE_TEMPLATE/robot_safety_issue.md
+++ b/.github/ISSUE_TEMPLATE/robot_safety_issue.md
@@ -1,0 +1,133 @@
+---
+name: Robot safety issue
+about: Report a possible unsafe robot behavior, motion, docking, navigation, or hardware interaction
+title: "[Safety]: "
+labels: safety
+assignees: ""
+---
+
+# Robot safety issue
+
+Use this template for issues that may affect:
+
+- physical robot safety
+- unsafe motion
+- docking risk
+- navigation collisions
+- hardware damage
+- unsafe deployment assumptions
+- unexpected actuator behavior
+
+---
+
+## Summary
+
+Briefly describe the safety concern.
+
+---
+
+## Affected behavior
+
+Select all that apply:
+
+- [ ] Unexpected robot movement
+- [ ] Navigation collision risk
+- [ ] Unsafe docking behavior
+- [ ] Motor control issue
+- [ ] Sensor failure or incorrect sensor interpretation
+- [ ] Hardware communication issue
+- [ ] Simulation-to-real-world mismatch
+- [ ] Emergency stop or safety system concern
+- [ ] Power or battery-related issue
+- [ ] Other
+
+---
+
+## Environment
+
+- Simulation or real robot:
+- OS:
+- ROS 2 distribution:
+- Gazebo / Gazebo Sim version:
+- Robot hardware version, if applicable:
+- Branch or commit:
+
+---
+
+## Steps to reproduce
+
+```bash
+# Paste exact commands or procedure here
+```
+
+---
+
+## Expected safe behavior
+
+Describe what should happen.
+
+---
+
+## Actual unsafe behavior
+
+Describe what happened.
+
+---
+
+## Risk level
+
+Select one:
+
+- [ ] Low
+- [ ] Medium
+- [ ] High
+- [ ] Critical
+
+---
+
+## Possible consequences
+
+Select all that apply:
+
+- [ ] Robot collision
+- [ ] Unsafe docking
+- [ ] Hardware damage
+- [ ] Motor overload
+- [ ] Sensor failure
+- [ ] Navigation instability
+- [ ] Human safety concern
+- [ ] Battery or power issue
+- [ ] Unknown
+
+---
+
+## Immediate mitigation
+
+Describe:
+
+- temporary workaround
+- safety stop procedure
+- disabled feature
+- deployment limitation
+- recommended precaution
+
+---
+
+## Logs, screenshots, or videos
+
+Attach:
+
+- terminal logs
+- RViz screenshots
+- Gazebo screenshots
+- videos
+- photos
+- diagnostics
+
+if possible.
+
+---
+
+## Additional notes
+
+Add any additional safety context.


### PR DESCRIPTION
## Summary

This PR adds GitHub issue templates for:

- bug reports
- feature requests
- robot safety issues

## Motivation

The templates improve:

- contributor onboarding
- issue quality
- debugging reproducibility
- robotics safety reporting
- simulation and hardware issue tracking

## Scope

This PR affects only GitHub repository tooling and issue management.

No robot runtime code, simulation behavior, or ROS2 package behavior was changed.

## Added

- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/ISSUE_TEMPLATE/robot_safety_issue.md`

## Safety impact

No runtime impact. Repository governance only.