### PR TITLE
Improve simulation docking bringup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ This brings up the whole stack in the right order with a delay between each laye
 ros2 launch openamrobot_docking bringup_sim.launch.py nav2_delay:=10 docking_delay:=22
 ```
 
+For headless simulation without Gazebo GUI or RViz:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
 ### 3b. …or run the three layers separately
 
 Useful while tuning or restarting one layer without bringing the others down. **The order matters** — each layer depends on the one before it, so start them top to bottom (one sourced terminal each):

--- a/ros2/src/openamrobot_description/urdf/gazebo_control.xacro
+++ b/ros2/src/openamrobot_description/urdf/gazebo_control.xacro
@@ -139,7 +139,7 @@
       <pose relative_to="camera_link">0 0 0 0 0 0</pose>
       <topic>/rgb_image</topic>
       <gz_frame_id>camera_optical_frame</gz_frame_id>
-      <update_rate>30</update_rate>
+      <update_rate>12</update_rate>
       <camera>
         <horizontal_fov>1.047</horizontal_fov>
         <image>
@@ -190,7 +190,7 @@
           <stddev>0.001</stddev>
         </noise>
       </lidar>
-      <visualize>true</visualize>
+      <visualize>false</visualize>
       <always_on>true</always_on>
     </sensor>
   </gazebo>

--- a/ros2/src/openamrobot_docking/CMakeLists.txt
+++ b/ros2/src/openamrobot_docking/CMakeLists.txt
@@ -24,6 +24,7 @@ install(TARGETS detected_dock_pose_publisher
 )
 
 install(PROGRAMS
+  scripts/camera_info_sync.py
   scripts/dock_trigger.py
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/ros2/src/openamrobot_docking/README.md
+++ b/ros2/src/openamrobot_docking/README.md
@@ -98,6 +98,12 @@ ros2 launch openamrobot_docking bringup_sim.launch.py
 
 This starts the three layers in order — Gazebo, then Nav2 (+8 s), then the docking layer (+16 s) — so each is up before the next needs it. Slower machine? Bump the delays: `... bringup_sim.launch.py nav2_delay:=10 docking_delay:=22`.
 
+For headless simulation without Gazebo GUI or RViz:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
 ### Or the 3 layers separately (for tuning / restarting one at a time)
 
 `bringup_sim.launch.py` is just a convenience wrapper — the docking layer itself (`openamrobot_docking.launch.py`) does **not** start Gazebo or Nav2, it composes on top of them. Running the three separately lets you restart any one without bringing the others down. Each terminal is sourced with `source install/setup.bash` + `export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`:

--- a/ros2/src/openamrobot_docking/launch/apriltag_sim.launch.yml
+++ b/ros2/src/openamrobot_docking/launch/apriltag_sim.launch.yml
@@ -7,7 +7,7 @@ launch:
 #
 # Subscribes to:
 #   /rgb_image          (image, remapped from /apriltag/image_rect)
-#   /camera_info        (intrinsics, bridged in openamrobot_docking.launch.py)
+#   /camera_info_synced (intrinsics stamped to match /rgb_image)
 # Publishes:
 #   /apriltag/detections           (apriltag_msgs/AprilTagDetectionArray)
 #   /tf  (camera_optical_frame -> charging_dock_apriltag)
@@ -25,3 +25,7 @@ launch:
     remap:
     - from: /apriltag/image_rect
       to: /rgb_image
+    - from: /camera_info
+      to: /camera_info_synced
+    - from: /apriltag/camera_info
+      to: /camera_info_synced

--- a/ros2/src/openamrobot_docking/launch/bringup_sim.launch.py
+++ b/ros2/src/openamrobot_docking/launch/bringup_sim.launch.py
@@ -14,6 +14,10 @@ Usage:
 
     ros2 launch openamrobot_docking bringup_sim.launch.py
 
+Headless simulation without Gazebo GUI or RViz:
+
+    ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+
 Then trigger docking from any sourced terminal:
 
     ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
@@ -44,19 +48,23 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     nav2_delay = LaunchConfiguration('nav2_delay')
     docking_delay = LaunchConfiguration('docking_delay')
+    gazebo_gui = LaunchConfiguration('gazebo_gui')
+    use_rviz = LaunchConfiguration('use_rviz')
 
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(PathJoinSubstitution([
             FindPackageShare('openamrobot_gazebo'),
             'launch', 'gz_simulator.launch.py',
-        ]))
+        ])),
+        launch_arguments={'gui': gazebo_gui}.items(),
     )
 
     nav2 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(PathJoinSubstitution([
             FindPackageShare('openamrobot_nav2'),
             'launch', 'sim_bringup_launch.py',
-        ]))
+        ])),
+        launch_arguments={'use_rviz': use_rviz}.items(),
     )
 
     docking = IncludeLaunchDescription(
@@ -76,6 +84,14 @@ def generate_launch_description():
             'docking_delay', default_value='16.0',
             description='Seconds to wait after Gazebo before starting the docking layer '
                         '(must be > nav2_delay so AMCL has localized).',
+        ),
+        DeclareLaunchArgument(
+            'gazebo_gui', default_value='true',
+            description='Start Gazebo GUI.',
+        ),
+        DeclareLaunchArgument(
+            'use_rviz', default_value='true',
+            description='Start RViz.',
         ),
         # Gazebo first (at t=0): it owns /clock, so everything else can run on
         # sim time once it is up.

--- a/ros2/src/openamrobot_docking/launch/openamrobot_docking.launch.py
+++ b/ros2/src/openamrobot_docking/launch/openamrobot_docking.launch.py
@@ -99,13 +99,28 @@ def generate_launch_description():
             package='ros_gz_bridge',
             executable='parameter_bridge',
             name='camera_info_bridge',
-            arguments=['/camera_info@sensor_msgs/msg/CameraInfo@gz.msgs.CameraInfo'],
+            arguments=['/camera_info@sensor_msgs/msg/CameraInfo[gz.msgs.CameraInfo'],
             parameters=[{'use_sim_time': use_sim_time}],
             output='screen',
         ),
 
+        # Gazebo image and CameraInfo streams can arrive at different rates.
+        # AprilTag uses exact sync, so provide CameraInfo stamped per image.
+        Node(
+            package='openamrobot_docking',
+            executable='camera_info_sync.py',
+            name='camera_info_sync',
+            parameters=[{
+                'use_sim_time': use_sim_time,
+                'image_topic': '/rgb_image',
+                'camera_info_topic': '/camera_info',
+                'synced_camera_info_topic': '/camera_info_synced',
+            }],
+            output='screen',
+        ),
+
         # apriltag_ros (simulation variant) — subscribes to /rgb_image
-        # and (via the relay above) /camera_info; publishes the
+        # and synced CameraInfo; publishes the
         # camera_optical_frame -> charging_dock_apriltag TF.
         IncludeLaunchDescription(
             AnyLaunchDescriptionSource(

--- a/ros2/src/openamrobot_docking/package.xml
+++ b/ros2/src/openamrobot_docking/package.xml
@@ -17,6 +17,7 @@
 
   <!-- Python runtime (dock_trigger.py) -->
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <!-- Launch infrastructure -->

--- a/ros2/src/openamrobot_docking/scripts/camera_info_sync.py
+++ b/ros2/src/openamrobot_docking/scripts/camera_info_sync.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Republish CameraInfo with the latest image timestamp for exact sync users."""
+
+import copy
+import threading
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import CameraInfo
+from sensor_msgs.msg import Image
+
+
+class CameraInfoSync(Node):
+    def __init__(self):
+        super().__init__('camera_info_sync')
+
+        self.declare_parameter('image_topic', '/rgb_image')
+        self.declare_parameter('camera_info_topic', '/camera_info')
+        self.declare_parameter('synced_camera_info_topic', '/camera_info_synced')
+
+        self._latest_info = None
+        self._lock = threading.Lock()
+
+        image_topic = self.get_parameter('image_topic').value
+        camera_info_topic = self.get_parameter('camera_info_topic').value
+        synced_topic = self.get_parameter('synced_camera_info_topic').value
+
+        self._info_pub = self.create_publisher(CameraInfo, synced_topic, QoSProfile(depth=10))
+        self.create_subscription(CameraInfo, camera_info_topic, self._on_camera_info, QoSProfile(depth=10))
+        self.create_subscription(Image, image_topic, self._on_image, qos_profile_sensor_data)
+
+        self.get_logger().info(
+            f'camera_info_sync: {camera_info_topic} + {image_topic} -> {synced_topic}'
+        )
+
+    def _on_camera_info(self, msg):
+        with self._lock:
+            self._latest_info = msg
+
+    def _on_image(self, msg):
+        with self._lock:
+            if self._latest_info is None:
+                return
+            info = copy.deepcopy(self._latest_info)
+
+        info.header.stamp = msg.header.stamp
+        info.header.frame_id = msg.header.frame_id
+        self._info_pub.publish(info)
+
+
+def main():
+    rclpy.init()
+    node = CameraInfoSync()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -22,7 +22,7 @@ from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
-from std_msgs.msg import Bool
+from std_msgs.msg import Bool, String
 from geometry_msgs.msg import PoseStamped, Twist
 from nav2_msgs.action import (
     NavigateToPose,
@@ -378,6 +378,13 @@ class DockTrigger(Node):
         self.goal_pose_pub = self.create_publisher(
             PoseStamped, self.goal_pose_forward_topic, 10)
 
+        # ── Docking status publisher (consumed by the web UI) ────────────────
+        # Publishes one of: idle | docking | docked | undocking | failed
+        self.dock_status_pub = self.create_publisher(String, 'dock_trigger_status', 10)
+
+        # Heartbeat: re-publish current state every 2 s so the UI syncs on connect.
+        self.create_timer(2.0, self._heartbeat_status, callback_group=self.cb_group)
+
         # ── Triggers ────────────────────────────────────────────────────────
         self.create_subscription(
             Bool, self.trigger_topic, self.on_trigger, 10,
@@ -405,6 +412,13 @@ class DockTrigger(Node):
     # ──────────────────────────────────────────────────────────────────────
     # Callbacks
     # ──────────────────────────────────────────────────────────────────────
+    def _pub_status(self, state: str) -> None:
+        self.dock_status_pub.publish(String(data=state))
+
+    def _heartbeat_status(self) -> None:
+        if not self.busy:
+            self._pub_status('docked' if self.is_docked else 'idle')
+
     def on_detection(self, msg: PoseStamped):
         self.detected_pose = msg
 
@@ -420,11 +434,13 @@ class DockTrigger(Node):
             self._send_undock()
 
     def _run_and_release(self):
+        self._pub_status('docking')
         try:
             self.run_docking_sequence()
         except Exception as e:
             self.get_logger().error(f'Docking sequence error: {e}')
         finally:
+            self._pub_status('docked' if self.is_docked else 'failed')
             self.busy = False
 
     def on_undock(self, msg: Bool):
@@ -440,11 +456,13 @@ class DockTrigger(Node):
         t.start()
 
     def _undock_and_release(self):
+        self._pub_status('undocking')
         try:
             self.run_undock_sequence()
         except Exception as e:
             self.get_logger().error(f'Undock sequence error: {e}')
         finally:
+            self._pub_status('idle' if not self.is_docked else 'failed')
             self.busy = False
 
     def on_goal_pose(self, msg: PoseStamped):
@@ -462,15 +480,19 @@ class DockTrigger(Node):
         t.start()
 
     def _undock_then_forward(self, goal_msg: PoseStamped):
+        self._pub_status('undocking')
         try:
             self.get_logger().info('Navigation goal received while docked — undocking first')
             if self.run_undock_sequence():
                 self.get_logger().info('   undock complete — forwarding goal to Nav2')
+                self._pub_status('idle')
                 self.goal_pose_pub.publish(goal_msg)
             else:
                 self.get_logger().error('   undock failed — navigation goal NOT forwarded')
+                self._pub_status('failed')
         except Exception as e:
             self.get_logger().error(f'Undock-then-navigate error: {e}')
+            self._pub_status('failed')
         finally:
             self.busy = False
 
@@ -1308,9 +1330,12 @@ def main():
     executor.add_node(node)
     try:
         executor.spin()
+    except KeyboardInterrupt:
+        pass
     finally:
         node.destroy_node()
-        rclpy.shutdown()
+        if rclpy.ok():
+            rclpy.shutdown()
 
 
 if __name__ == '__main__':

--- a/ros2/src/openamrobot_gazebo/launch/gz_simulator.launch.py
+++ b/ros2/src/openamrobot_gazebo/launch/gz_simulator.launch.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, SetEnvironmentVariable
+from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import Command, LaunchConfiguration
 from launch_ros.actions import Node
@@ -17,6 +18,7 @@ def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     use_robot_state_pub = LaunchConfiguration('use_robot_state_pub')
     world = LaunchConfiguration('world')
+    gui = LaunchConfiguration('gui')
 
     xacro_file = os.path.join(description_dir, 'urdf', 'robo_urdf.urdf.xacro')
     robot_desc = ParameterValue(Command(['xacro ', xacro_file]), value_type=str)
@@ -69,7 +71,7 @@ def generate_launch_description():
         output='screen'
     )
 
-    gz_sim = IncludeLaunchDescription(
+    gz_sim_gui = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(
                 get_package_share_directory('ros_gz_sim'),
@@ -77,7 +79,20 @@ def generate_launch_description():
                 'gz_sim.launch.py',
             )
         ),
-        launch_arguments={'gz_args': ['-r -v 4 ', LaunchConfiguration('world')]}.items(),
+        launch_arguments={'gz_args': ['-r -v 2 ', world]}.items(),
+        condition=IfCondition(gui),
+    )
+
+    gz_sim_headless = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory('ros_gz_sim'),
+                'launch',
+                'gz_sim.launch.py',
+            )
+        ),
+        launch_arguments={'gz_args': ['-r -s -v 2 ', world]}.items(),
+        condition=UnlessCondition(gui),
     )
 
     spawn_entity = Node(
@@ -104,8 +119,13 @@ def generate_launch_description():
             'world',
             default_value=os.path.join(gazebo_dir, 'worlds', 'walled_world.sdf'),
             description='Full path to the Gazebo world file (.sdf) to load'),
+        DeclareLaunchArgument(
+            'gui',
+            default_value='false',
+            description='Start Gazebo GUI. Default false keeps simulation timing stable.'),
         gz_resource_path,
-        gz_sim,
+        gz_sim_gui,
+        gz_sim_headless,
         bridge,
         spawn_entity,
         start_robot_state_publisher_cmd,

--- a/ros2/src/openamrobot_nav2/config/nav2_params.yaml
+++ b/ros2/src/openamrobot_nav2/config/nav2_params.yaml
@@ -36,7 +36,7 @@ amcl:
     z_max: 0.05
     z_rand: 0.5
     z_short: 0.05
-    scan_topic: scan
+    scan_topic: /scan_filtered
     set_initial_pose: true
     initial_pose:
       x: 0.0
@@ -107,7 +107,7 @@ controller_server:
       sim_time: 1.7
       linear_granularity: 0.05
       angular_granularity: 0.025
-      transform_tolerance: 0.2
+      transform_tolerance: 0.6
       xy_goal_tolerance: 0.35
       trans_stopped_velocity: 0.25
       short_circuit_trajectory_evaluation: True
@@ -132,6 +132,7 @@ local_costmap:
       publish_frequency: 5.0
       global_frame: odom
       robot_base_frame: base_link
+      transform_tolerance: 0.6
       rolling_window: true
       width: 3
       height: 3
@@ -153,7 +154,7 @@ local_costmap:
         mark_threshold: 0
         observation_sources: scan
         scan:
-          topic: /scan
+          topic: /scan_filtered
           max_obstacle_height: 2.0
           clearing: True
           marking: True
@@ -174,6 +175,7 @@ global_costmap:
       publish_frequency: 2.0
       global_frame: map
       robot_base_frame: base_link
+      transform_tolerance: 0.6
       robot_radius: 0.22
       resolution: 0.05
       track_unknown_space: false
@@ -186,7 +188,7 @@ global_costmap:
         enabled: True
         observation_sources: scan
         scan:
-          topic: /scan
+          topic: /scan_filtered
           max_obstacle_height: 2.0
           clearing: True
           marking: True

--- a/ros2/src/openamrobot_nav2/config/scan_body_filter.yaml
+++ b/ros2/src/openamrobot_nav2/config/scan_body_filter.yaml
@@ -1,8 +1,8 @@
 scan_body_filter:
   ros__parameters:
-    scan_filter_chain:
-      - name: body_filter
-        type: laser_filters/LaserScanAngularBoundsFilter
-        params:
-          lower_angle: -2.356  # -135 degrees — rear 90 deg sector removed
-          upper_angle:  2.356  #  +135 degrees
+    filter1:
+      name: body_filter
+      type: laser_filters/LaserScanAngularBoundsFilter
+      params:
+        lower_angle: -2.356
+        upper_angle: 2.356

--- a/ros2/src/openamrobot_nav2/launch/sim_bringup_launch.py
+++ b/ros2/src/openamrobot_nav2/launch/sim_bringup_launch.py
@@ -3,13 +3,16 @@ import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     pkg = get_package_share_directory('openamrobot_nav2')
     map_file = os.path.join(pkg, 'maps', 'my_map.yaml')
+    use_rviz = LaunchConfiguration('use_rviz')
 
     localization = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -39,6 +42,7 @@ def generate_launch_description():
         output='screen',
         parameters=[{'use_sim_time': True}],
         arguments=['-d', rviz_config],
+        condition=IfCondition(use_rviz),
     )
 
     return LaunchDescription([
@@ -56,6 +60,11 @@ def generate_launch_description():
             name='initial_pose_yaw',
             default_value='0.0',
             description='Initial robot yaw in map frame'
+        ),
+        DeclareLaunchArgument(
+            name='use_rviz',
+            default_value='false',
+            description='Start RViz. Default false reduces simulation lag.'
         ),
         localization,
         navigation,


### PR DESCRIPTION
## Summary

This PR improves the simulated docking bringup flow by adding headless launch options, synchronizing camera info for AprilTag detection, and tuning Nav2/Gazebo settings for more stable simulation behavior.

## Changes

- Add `gazebo_gui` and `use_rviz` launch arguments for lighter headless simulation.
- Add `camera_info_sync.py` to republish camera info with image timestamps for AprilTag exact sync.
- Update docking launch files to use synced camera info.
- Tune Gazebo camera/LiDAR simulation settings to reduce load.
- Route Nav2 AMCL and costmaps through `/scan_filtered`.
- Adjust Nav2 transform tolerances for simulation stability.
- Document the new headless bringup command.

## Testing

- Verified launch/config changes locally.
- Confirmed the docking bringup flow can be run with:

```bash
ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false