### PR TITLE
Update README with file organization rules

### DIFF
--- a/ros2/src/openamrobot_gazebo/README.md
+++ b/ros2/src/openamrobot_gazebo/README.md
@@ -4,6 +4,9 @@ ROS 2 Gazebo Harmonic simulation package for the **OpenAMRobot** mobile base.
 
 Contains: world files, ROS–Gazebo bridge configuration, and simulation launch files.
 
+> **Rule:** If a file must be used by `ros2 launch`, keep it inside `openamrobot_gazebo`.
+> **Rule:** If a file is a project-level scenario, design asset, experimental environment, or documentation/reference asset, keep it in `simulation/`.
+
 ## Contents
 
 ```


### PR DESCRIPTION
Added rules for file organization in README.

# Pull Request Summary

Briefly explain what this Pull Request does.

Example:

- add 
> **Rule:** If a file must be used by `ros2 launch`, keep it inside `openamrobot_gazebo`.
> **Rule:** If a file is a project-level scenario, design asset, experimental environment, or documentation/reference asset, keep it in `simulation/`.

---

# Scope of changes

This PR modifies:

- [X] documentation

Exact scope:

```text
> **Rule:** If a file must be used by `ros2 launch`, keep it inside `openamrobot_gazebo`.
> **Rule:** If a file is a project-level scenario, design asset, experimental environment, or documentation/reference asset, keep it in `simulation/`.
```

---

# Motivation

To avoid duplicating and distinguish directories, make it clear which use when

---

# Architecture and package responsibility

Checklist:

- [ X] I modified only files related to the intended package scope
- [X ] I did not duplicate files from other ROS 2 packages
- [X ] I referenced existing packages instead of copying their contents
- [X] I verified that unrelated packages were not modified accidentally


---

