### PR TITLE
Add beginner Git and GitHub guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,26 @@ You can contribute by:
 
 Do not push directly to `main` of the org repository. All changes go through Pull Requests.
 
+## Helpful Contributor Docs
+
+Use these docs while preparing a contribution:
+
+| Topic | Guide |
+|---|---|
+| Git, forks, branches, and PRs | [`docs/getting_started/GIT_GUIDE.md`](docs/getting_started/GIT_GUIDE.md) |
+| Local development setup | [`docs/getting_started/DEVELOPER_SETUP.md`](docs/getting_started/DEVELOPER_SETUP.md) |
+| Testing checklist | [`docs/getting_started/TESTING_GUIDE.md`](docs/getting_started/TESTING_GUIDE.md) |
+| Troubleshooting | [`docs/getting_started/TROUBLESHOOTING.md`](docs/getting_started/TROUBLESHOOTING.md) |
+| System architecture | [`docs/architecture/ARCHITECTURE_OVERVIEW.md`](docs/architecture/ARCHITECTURE_OVERVIEW.md) |
+
 ## Building and testing locally
 
 Before opening a PR, verify your changes build and run end-to-end:
 
 ```bash
+cd openamr-platform-sw/ros2
 source /opt/ros/jazzy/setup.bash
-colcon build --packages-up-to openamrobot_docking
+colcon build --symlink-install --packages-up-to openamrobot_docking
 source install/setup.bash
 
 # Smoke tests — each in its own terminal:
@@ -72,6 +85,36 @@ ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
 
 The PR description must include a **Test plan** section recording which of these smoke tests you ran and the outcomes.
 
+For a fuller checklist by change type, see [`docs/getting_started/TESTING_GUIDE.md`](docs/getting_started/TESTING_GUIDE.md).
+
+## Before Opening a Pull Request
+
+Check these before submitting:
+
+- Your branch name is clear, for example `docs/...`, `fix/...`, `feature/...`, `chore/...`, or `test/...`.
+- Your commits are signed off for DCO.
+- The change is focused and does not include unrelated edits.
+- Relevant docs are updated for any changed launch files, topics, parameters, TF frames, or package behavior.
+- Generated files are not staged.
+- The relevant build or smoke test has been run.
+- The PR description includes a summary and test plan.
+
+Recommended PR description shape:
+
+```markdown
+## Summary
+
+- Explain what changed and why.
+
+## Test plan
+
+- List the commands or smoke tests you ran.
+
+## Notes
+
+- Mention limitations, follow-up work, or anything reviewers should know.
+```
+
 ## Developer Certificate of Origin
 
 This repository uses the Developer Certificate of Origin (DCO).
@@ -85,6 +128,15 @@ Each commit must include a sign-off line:
 The easiest way is to commit with `-s`:
 
     git commit -s -m "your commit message"
+
+If GitHub reports a DCO failure on your latest commit, amend it:
+
+```bash
+git commit --amend --signoff --no-edit
+git push --force-with-lease origin your-branch-name
+```
+
+Use `--force-with-lease` only for your own branch after intentionally amending or rebasing commits.
 
 ## Legal Notice for Contributions
 
@@ -149,15 +201,17 @@ Simulation contributions must include:
 - required ROS 2 distribution (Jazzy at time of writing)
 - required Gazebo / Ignition version (Harmonic at time of writing)
 - expected behaviour
-- tested scenario (`walled_world.sdf` / `docking_scenario.sdf` / new world)
+- tested scenario (`walled_world.sdf` / modified world / new world)
 - known limitations
 - required models, worlds, and configuration files
 - screenshots or logs if useful
 
 **Do not commit generated folders.** The repository `.gitignore` already excludes:
 
-- `build/`, `install/`, `log/` (colcon outputs)
+- `ros2/build/`, `ros2/install/`, `ros2/log/` (colcon outputs)
+- root-level `build/`, `install/`, `log/` if accidentally created by building from the wrong directory
 - `__pycache__/`, `*.pyc` (Python caches)
+- `.pytest_cache/`
 - Gazebo runtime caches
 
 If you find any of these tracked in git, remove them with `git rm --cached -r <path>`.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ROS 2 Jazzy software stack for the **OpenAMRobot** mobile robot platform: robot 
 
 📖 **[README](README.md)** &nbsp;·&nbsp;
 🤝 **[Contributing](CONTRIBUTING.md)** &nbsp;·&nbsp;
+🌱 **[Git guide](docs/getting_started/GIT_GUIDE.md)** &nbsp;·&nbsp;
 📜 **[License](LICENSE)** &nbsp;·&nbsp;
 🔒 **[Security](SECURITY.md)** &nbsp;·&nbsp;
 👥 **[Authors](AUTHORS.md)** &nbsp;·&nbsp;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ROS 2 Jazzy software stack for the **OpenAMRobot** mobile robot platform: robot 
 
 📖 **[README](README.md)** &nbsp;·&nbsp;
 🤝 **[Contributing](CONTRIBUTING.md)** &nbsp;·&nbsp;
+🏗️ **[Architecture](docs/architecture/ARCHITECTURE_OVERVIEW.md)** &nbsp;·&nbsp;
+🛠️ **[Developer setup](docs/getting_started/DEVELOPER_SETUP.md)** &nbsp;·&nbsp;
+🧰 **[Troubleshooting](docs/getting_started/TROUBLESHOOTING.md)** &nbsp;·&nbsp;
+✅ **[Testing](docs/getting_started/TESTING_GUIDE.md)** &nbsp;·&nbsp;
 🌱 **[Git guide](docs/getting_started/GIT_GUIDE.md)** &nbsp;·&nbsp;
 📜 **[License](LICENSE)** &nbsp;·&nbsp;
 🔒 **[Security](SECURITY.md)** &nbsp;·&nbsp;

--- a/docs/architecture/ARCHITECTURE_OVERVIEW.md
+++ b/docs/architecture/ARCHITECTURE_OVERVIEW.md
@@ -1,0 +1,476 @@
+# Architecture Overview
+
+This document explains the high-level architecture of `openamr-platform-sw`.
+
+It is meant as a system map for contributors. The README gives a short quickstart; this file explains how the main ROS 2 packages fit together, which package owns which responsibility, and how data moves through the simulation, navigation, and docking stack.
+
+For detailed docking internals, see:
+
+```text
+ros2/src/openamrobot_docking/docs/02_architecture.md
+ros2/src/openamrobot_docking/docs/03_tf_frames.md
+ros2/src/openamrobot_docking/docs/08_sequencer_4phase.md
+```
+
+---
+
+## 1. System Scope
+
+`openamr-platform-sw` is the ROS 2 software stack for the OpenAMRobot mobile robot platform.
+
+The current working path is the simulation stack:
+
+```text
+Gazebo Harmonic -> ROS 2 bridge -> Nav2 -> AprilTag docking sequencer
+```
+
+The active, buildable packages are:
+
+| Package | Responsibility |
+|---|---|
+| `openamrobot_description` | Robot URDF/xacro, meshes, sensor frames, Gazebo plugin tags |
+| `openamrobot_gazebo` | Gazebo world launch, robot spawn, `ros_gz_bridge` configuration |
+| `openamrobot_nav2` | Map, AMCL localization, Nav2 stack, RViz navigation layout |
+| `openamrobot_docking` | AprilTag detection launch, dock pose publishing, dock/undock sequencer |
+
+The reserved placeholder areas are:
+
+| Area | Planned responsibility |
+|---|---|
+| `openamrobot_bringup` | Future top-level real-robot launch compositions |
+| `openamrobot_control` | Future low-level control and `ros2_control` integration |
+| `openamrobot_drivers` | Future hardware drivers for lidar, camera, motor controller, IMU |
+| `openamrobot_perception` | Future perception beyond docking |
+
+The placeholders reserve architectural space but are not the working simulation stack today.
+
+---
+
+## 2. Workspace Layout
+
+The repository root is:
+
+```text
+openamr-platform-sw/
+```
+
+The ROS 2 workspace root is:
+
+```text
+openamr-platform-sw/ros2/
+```
+
+Build from `ros2/`:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+The package layout is:
+
+```text
+ros2/src/
+├── openamrobot_description/
+├── openamrobot_gazebo/
+├── openamrobot_nav2/
+├── openamrobot_docking/
+├── openamrobot_bringup/       reserved placeholder
+├── openamrobot_control/       reserved placeholder
+├── openamrobot_drivers/       reserved placeholder
+└── openamrobot_perception/    reserved placeholder
+```
+
+---
+
+## 3. Package Boundaries
+
+The project keeps package ownership strict so files are easy to find and changes do not leak across layers.
+
+| Package | Owns | Should not own |
+|---|---|---|
+| `openamrobot_description` | URDF/xacro, meshes, robot links, joints, sensor frames, Gazebo plugin tags attached to the robot | Worlds, maps, Nav2 parameters, docking logic |
+| `openamrobot_gazebo` | Gazebo world launch, robot spawn, ROS/Gazebo bridge configuration, world files | Robot URDF source, Nav2 config, docking sequence logic |
+| `openamrobot_nav2` | AMCL, Nav2 launch files, maps, RViz navigation config, navigation parameters | Gazebo launch, robot meshes, AprilTag/docking control |
+| `openamrobot_docking` | AprilTag launch, camera info sync, dock pose publisher, dock model, docking sequencer, one-command sim bringup wrapper | Robot model, Gazebo bridge base config, Nav2 internals |
+
+Packages may reference each other through launch composition using `FindPackageShare` and `IncludeLaunchDescription`.
+
+Packages should not duplicate another package's files.
+
+---
+
+## 4. One-Command Simulation Bringup
+
+The main simulation entry point is:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+This launch file composes three layers:
+
+| Startup order | Package | Launch file | Purpose |
+|---|---|---|---|
+| 1 | `openamrobot_gazebo` | `gz_simulator.launch.py` | Start Gazebo, spawn robot, publish robot description, bridge Gazebo topics |
+| 2 | `openamrobot_nav2` | `sim_bringup_launch.py` | Start AMCL, Nav2, map server, optional RViz |
+| 3 | `openamrobot_docking` | `openamrobot_docking.launch.py` | Start AprilTag detection, dock pose publisher, dock trigger node |
+
+`bringup_sim.launch.py` starts Gazebo immediately, Nav2 after `nav2_delay`, and docking after `docking_delay`.
+
+Default timing:
+
+```text
+Gazebo:  t + 0 s
+Nav2:    t + 8 s
+Docking: t + 16 s
+```
+
+On slower machines:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py nav2_delay:=10 docking_delay:=22
+```
+
+Headless mode:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+---
+
+## 5. Layer Responsibilities
+
+### Gazebo Layer
+
+Started by:
+
+```bash
+ros2 launch openamrobot_gazebo gz_simulator.launch.py
+```
+
+Main responsibilities:
+
+- Load the Gazebo world.
+- Expand the robot xacro into `/robot_description`.
+- Spawn the robot into Gazebo.
+- Start `robot_state_publisher`.
+- Start `joint_state_publisher`.
+- Start `ros_gz_bridge` using `openamrobot_gazebo/config/gz_bridge.yaml`.
+
+Important topics bridged by this layer:
+
+| Topic | Direction | Purpose |
+|---|---|---|
+| `/clock` | Gazebo to ROS | Simulation time |
+| `/tf` | Gazebo to ROS | Dynamic transforms from simulation |
+| `/odom` | Gazebo to ROS | Odometry |
+| `/scan` | Gazebo to ROS | 2D lidar |
+| `/rgb_image` | Gazebo to ROS | Simulated RGB camera image |
+| `/cmd_vel` | ROS to Gazebo | Velocity command to the diff-drive plugin |
+
+Gazebo also publishes camera info. The docking layer bridges the root-level `/camera_info` topic needed by the AprilTag pipeline.
+
+### Navigation Layer
+
+Started by:
+
+```bash
+ros2 launch openamrobot_nav2 sim_bringup_launch.py
+```
+
+Main responsibilities:
+
+- Start localization on `maps/my_map.yaml`.
+- Start the Nav2 planner, controller, behavior server, BT navigator, velocity smoother, and collision monitor.
+- Start RViz if `use_rviz:=true`.
+- Provide the `/navigate_to_pose` action used by docking Phase 1.
+
+Important inputs:
+
+| Input | Why it matters |
+|---|---|
+| `/scan` | Costmaps and localization |
+| `/odom` | Robot motion estimate |
+| `/tf` | Frame relationships |
+| `/map` | Static map for localization and planning |
+
+Important navigation interfaces:
+
+| Interface | Purpose |
+|---|---|
+| `/navigate_to_pose` | Action server for navigation goals |
+| `/goal_pose_nav` | Goal topic consumed by Nav2 after the docking gate remap |
+| `/cmd_vel` | Final velocity command after Nav2 smoothing/collision monitoring |
+
+### Docking Layer
+
+Started by:
+
+```bash
+ros2 launch openamrobot_docking openamrobot_docking.launch.py
+```
+
+Main responsibilities:
+
+- Bridge Gazebo camera info to ROS `/camera_info`.
+- Stamp camera info to match `/rgb_image` as `/camera_info_synced`.
+- Start AprilTag detection on `/rgb_image` and `/camera_info_synced`.
+- Publish the detected dock pose in the `map` frame.
+- Run the Python dock/undock trigger node.
+
+Important nodes:
+
+| Node | Purpose |
+|---|---|
+| `camera_info_bridge` | Bridges Gazebo camera info to root-level ROS `/camera_info` |
+| `camera_info_sync` | Produces `/camera_info_synced` stamped with image time |
+| `apriltag_ros` node | Detects the dock AprilTag from the camera image |
+| `detected_dock_pose_publisher` | Converts tag TF into `/detected_dock_pose` |
+| `dock_trigger.py` | Runs the 4-phase docking and undocking sequence |
+
+Important topics:
+
+| Topic | Purpose |
+|---|---|
+| `/dock_trigger` | Publish `std_msgs/Bool true` to start docking |
+| `/undock_robot` | Publish `std_msgs/Bool true` to undock |
+| `/rgb_image` | Camera image used by AprilTag detection |
+| `/camera_info` | Raw bridged camera info |
+| `/camera_info_synced` | Camera info stamped to match image frames |
+| `/apriltag/detections` | Raw AprilTag detections |
+| `/detected_dock_pose` | Dock pose as `PoseStamped` in `map` |
+| `/cmd_vel` | Direct velocity output during docking phases 2, 3, and 4 |
+
+---
+
+## 6. Main Data Flow
+
+The current simulation data flow is:
+
+```text
+Gazebo world
+  -> sensors and robot physics
+  -> ros_gz_bridge
+  -> ROS topics: /clock, /scan, /odom, /tf, /rgb_image
+  -> Nav2 localization and planning
+  -> docking AprilTag detection
+  -> dock_trigger.py
+  -> /cmd_vel
+  -> ros_gz_bridge
+  -> Gazebo diff-drive plugin
+  -> robot motion
+```
+
+The shortest useful mental model:
+
+```text
+Sensors -> localization -> planning/docking -> /cmd_vel -> Gazebo wheels
+```
+
+If the robot does not move, debug from right to left:
+
+1. Is `/cmd_vel` being published?
+2. Is `ros_gz_bridge` subscribed to `/cmd_vel`?
+3. Is Gazebo running?
+4. Is the diff-drive plugin loaded?
+5. Are `/odom` and `/tf` changing?
+
+---
+
+## 7. Velocity Command Flow
+
+All motion eventually reaches Gazebo through ROS `/cmd_vel`.
+
+Navigation flow:
+
+```text
+Nav2 controller
+  -> /cmd_vel_nav
+  -> velocity_smoother
+  -> /cmd_vel_smoothed
+  -> collision_monitor
+  -> /cmd_vel
+  -> ros_gz_bridge
+  -> Gazebo /cmd_vel
+  -> DiffDrive plugin
+```
+
+Docking flow:
+
+```text
+dock_trigger.py
+  -> /navigate_to_pose action during Phase 1
+  -> direct /cmd_vel during Phases 2, 3, and 4
+  -> ros_gz_bridge
+  -> Gazebo /cmd_vel
+  -> DiffDrive plugin
+```
+
+This split is intentional. Phase 1 uses Nav2 to reach the staging zone. The final camera-guided scan, align, and approach phases publish directly to `/cmd_vel` for precise, simple control.
+
+---
+
+## 8. Perception and Dock Pose Flow
+
+The docking perception chain is:
+
+```text
+Gazebo camera
+  -> /rgb_image
+  -> /camera_info
+  -> camera_info_sync
+  -> /camera_info_synced
+  -> apriltag_ros
+  -> TF: camera_optical_frame -> charging_dock_apriltag
+  -> detected_dock_pose_publisher
+  -> /detected_dock_pose
+  -> dock_trigger.py
+```
+
+`apriltag_ros` publishes the tag transform. `detected_dock_pose_publisher` looks up the tag in the `map` frame and republishes it as a `PoseStamped`.
+
+This lets the docking sequencer reason about the dock in the same global frame used by Nav2.
+
+---
+
+## 9. TF Architecture
+
+The key frame chain is:
+
+```text
+map
+  -> odom
+  -> base_link
+  -> camera_link
+  -> camera_optical_frame
+  -> charging_dock_apriltag
+```
+
+Frame ownership:
+
+| Transform | Publisher |
+|---|---|
+| `map -> odom` | AMCL/localization |
+| `odom -> base_link` | Gazebo diff-drive odometry through the bridge |
+| `base_link -> camera_link` | `robot_state_publisher` from URDF |
+| `camera_link -> camera_optical_frame` | `robot_state_publisher` from URDF |
+| `camera_optical_frame -> charging_dock_apriltag` | `apriltag_ros` |
+
+Useful checks:
+
+```bash
+ros2 run tf2_ros tf2_echo map base_link
+ros2 run tf2_ros tf2_echo base_link camera_optical_frame
+ros2 run tf2_ros tf2_echo map charging_dock_apriltag
+```
+
+Generate a TF diagram:
+
+```bash
+ros2 run tf2_tools view_frames
+```
+
+For deeper TF details:
+
+```text
+ros2/src/openamrobot_docking/docs/03_tf_frames.md
+```
+
+---
+
+## 10. Docking Sequence
+
+The current simulation docking path is a custom 4-phase sequencer in:
+
+```text
+ros2/src/openamrobot_docking/scripts/dock_trigger.py
+```
+
+Trigger:
+
+```bash
+ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
+```
+
+Phases:
+
+| Phase | Behavior | Main dependency |
+|---|---|---|
+| 1 | Navigate to staging pose near the dock | Nav2 `/navigate_to_pose` |
+| 2 | Rotate/scan until the AprilTag is centered, then collect filtered samples | Camera, AprilTag, TF |
+| 3 | Spin in place to align perpendicular to the dock | TF and `/cmd_vel` |
+| 4 | Drive forward along the filtered dock line until final distance | TF and `/cmd_vel` |
+
+Undock:
+
+```bash
+ros2 topic pub /undock_robot std_msgs/msg/Bool "{data: true}" --once
+```
+
+For phase-level detail:
+
+```text
+ros2/src/openamrobot_docking/docs/08_sequencer_4phase.md
+```
+
+---
+
+## 11. Simulation Time
+
+The simulation uses Gazebo `/clock`.
+
+Every simulation node should use:
+
+```text
+use_sim_time: true
+```
+
+Why this matters:
+
+- TF timestamps must agree.
+- Nav2 costmaps depend on consistent time.
+- AprilTag transforms must line up with camera frames.
+- Mixed wall time and sim time can cause TF extrapolation errors.
+
+Quick check:
+
+```bash
+ros2 topic echo /clock --once
+```
+
+If TF errors mention extrapolation into the future or past, check `use_sim_time` first.
+
+---
+
+## 12. Design Rules for Contributors
+
+Use these rules when changing the architecture:
+
+1. Keep robot model files in `openamrobot_description`.
+2. Keep Gazebo worlds and bridge config in `openamrobot_gazebo`.
+3. Keep navigation maps, Nav2 params, and RViz navigation layouts in `openamrobot_nav2`.
+4. Keep AprilTag, dock pose, and docking sequence logic in `openamrobot_docking`.
+5. Do not duplicate files across packages.
+6. Prefer launch composition over copying package assets.
+7. Document topic, TF, parameter, or launch behavior changes in the owning package README.
+8. For simulation changes, test the one-command bringup and the three-layer manual bringup.
+
+---
+
+## 13. Where to Read Next
+
+| Topic | Document |
+|---|---|
+| Beginner setup | `docs/getting_started/DEVELOPER_SETUP.md` |
+| General troubleshooting | `docs/getting_started/TROUBLESHOOTING.md` |
+| Git and fork workflow | `docs/getting_started/GIT_GUIDE.md` |
+| Docking architecture | `ros2/src/openamrobot_docking/docs/02_architecture.md` |
+| TF frames | `ros2/src/openamrobot_docking/docs/03_tf_frames.md` |
+| AprilTag setup | `ros2/src/openamrobot_docking/docs/04_apriltag.md` |
+| Docking parameters | `ros2/src/openamrobot_docking/docs/05_parameters.md` |
+| 4-phase sequencer | `ros2/src/openamrobot_docking/docs/08_sequencer_4phase.md` |
+| Docking troubleshooting | `ros2/src/openamrobot_docking/docs/09_troubleshooting.md` |

--- a/docs/getting_started/DEVELOPER_SETUP.md
+++ b/docs/getting_started/DEVELOPER_SETUP.md
@@ -1,0 +1,482 @@
+# Developer Setup Guide
+
+This guide explains how to set up a local development environment for `openamr-platform-sw`.
+
+The README gives the fastest path to run the simulation. This document gives more detail for contributors who need to build, rebuild, debug, and work on the repository regularly.
+
+---
+
+## 1. Supported System
+
+Recommended development environment:
+
+| Item | Version |
+|---|---|
+| Operating system | Ubuntu 24.04 Noble |
+| ROS 2 | Jazzy |
+| Gazebo | Harmonic |
+| Build tool | colcon |
+| DDS/RMW | CycloneDDS |
+
+Native Ubuntu is recommended. Gazebo and RViz need graphical support, so a full Linux desktop environment is easier than WSL or a headless machine.
+
+---
+
+## 2. Repository Structure
+
+The Git repository root is:
+
+```text
+openamr-platform-sw/
+```
+
+The ROS 2 workspace is inside:
+
+```text
+openamr-platform-sw/ros2/
+```
+
+This matters because `colcon build` should be run from `ros2/`, not from the repository root.
+
+Correct:
+
+```bash
+cd openamr-platform-sw/ros2
+colcon build --symlink-install
+```
+
+Incorrect:
+
+```bash
+cd openamr-platform-sw
+colcon build --symlink-install
+```
+
+---
+
+## 3. Install Required Packages
+
+Update package lists:
+
+```bash
+sudo apt update
+```
+
+Install the ROS 2, Gazebo, navigation, docking, and development packages used by the current simulation stack:
+
+```bash
+sudo apt install -y \
+  ros-jazzy-nav2-bringup ros-jazzy-nav2-amcl ros-jazzy-nav2-lifecycle-manager \
+  ros-jazzy-slam-toolbox ros-jazzy-laser-filters \
+  ros-jazzy-apriltag-ros ros-jazzy-image-proc \
+  ros-jazzy-ros-gz-sim ros-jazzy-ros-gz-bridge ros-jazzy-ros-gz-image \
+  ros-jazzy-robot-state-publisher ros-jazzy-joint-state-publisher \
+  ros-jazzy-tf2-ros ros-jazzy-tf2-tools ros-jazzy-tf2-geometry-msgs \
+  ros-jazzy-rmw-cyclonedds-cpp ros-jazzy-topic-tools ros-jazzy-rviz2 \
+  python3-colcon-common-extensions
+```
+
+This assumes ROS 2 Jazzy is already installed and available at `/opt/ros/jazzy/`.
+
+Check that the ROS 2 environment is available:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+echo $ROS_DISTRO
+ros2 pkg list
+```
+
+The first command should print `jazzy`.
+
+---
+
+## 4. Configure CycloneDDS
+
+This project uses CycloneDDS for the current docking simulation workflow.
+
+Set it in your current terminal:
+
+```bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+To make it available in every new terminal:
+
+```bash
+echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Check it:
+
+```bash
+echo $RMW_IMPLEMENTATION
+```
+
+Expected output:
+
+```text
+rmw_cyclonedds_cpp
+```
+
+---
+
+## 5. Clone the Repository
+
+For read-only use:
+
+```bash
+git clone https://github.com/openAMRobot/openamr-platform-sw.git
+cd openamr-platform-sw
+```
+
+For contribution work, fork the repository first, then clone your fork:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/openamr-platform-sw.git
+cd openamr-platform-sw
+git remote add upstream https://github.com/openAMRobot/openamr-platform-sw.git
+```
+
+For the full Git and fork workflow, see:
+
+```text
+docs/getting_started/GIT_GUIDE.md
+```
+
+---
+
+## 6. Build the Workspace
+
+Go to the ROS 2 workspace:
+
+```bash
+cd ros2
+```
+
+Source ROS 2:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+```
+
+Build:
+
+```bash
+colcon build --symlink-install
+```
+
+Source the local workspace:
+
+```bash
+source install/setup.bash
+```
+
+Why `--symlink-install` is useful:
+
+- Python files and launch files update more easily during development.
+- You do not need a full rebuild after every small script or launch-file edit.
+- It is the normal development mode for ROS 2 workspaces.
+
+---
+
+## 7. Source the Environment in Every New Terminal
+
+Every new terminal needs the environment again.
+
+From `openamr-platform-sw/ros2`:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+If you forget this, ROS 2 may not find the packages:
+
+```text
+package 'openamrobot_...' not found
+```
+
+---
+
+## 8. Verify the Build
+
+Check that packages are visible:
+
+```bash
+ros2 pkg list | grep openamrobot
+```
+
+Expected packages include:
+
+```text
+openamrobot_description
+openamrobot_docking
+openamrobot_gazebo
+openamrobot_nav2
+```
+
+Launch the full simulation stack:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+If your machine is slow, use larger startup delays:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py nav2_delay:=10 docking_delay:=22
+```
+
+For a lighter headless run:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+---
+
+## 9. Run the Main Layers Separately
+
+Running layers separately is useful during debugging.
+
+Open three sourced terminals from `ros2/`.
+
+Terminal 1, simulation:
+
+```bash
+ros2 launch openamrobot_gazebo gz_simulator.launch.py
+```
+
+Terminal 2, navigation:
+
+```bash
+ros2 launch openamrobot_nav2 sim_bringup_launch.py
+```
+
+Terminal 3, docking:
+
+```bash
+ros2 launch openamrobot_docking openamrobot_docking.launch.py
+```
+
+The order matters. Start simulation first, then navigation, then docking.
+
+---
+
+## 10. Test Dock and Undock
+
+From a sourced terminal:
+
+```bash
+ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
+```
+
+To undock:
+
+```bash
+ros2 topic pub /undock_robot std_msgs/msg/Bool "{data: true}" --once
+```
+
+Useful checks:
+
+```bash
+ros2 topic list
+ros2 topic info /cmd_vel
+ros2 topic echo /odom --once
+ros2 action list
+```
+
+---
+
+## 11. Rebuild After Changes
+
+For many Python or launch-file changes, rebuild may not be required when using `--symlink-install`.
+
+For package metadata, dependencies, generated files, or installed resource changes, rebuild:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+To build one package and its dependencies:
+
+```bash
+colcon build --symlink-install --packages-up-to openamrobot_docking
+```
+
+To build one package only:
+
+```bash
+colcon build --symlink-install --packages-select openamrobot_docking
+```
+
+---
+
+## 12. Clean Build Outputs
+
+Generated build folders live inside `ros2/`:
+
+```text
+ros2/build/
+ros2/install/
+ros2/log/
+```
+
+They should not be committed.
+
+If a build gets into a strange state, you can remove those folders and rebuild:
+
+```bash
+cd openamr-platform-sw/ros2
+rm -rf build install log
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+```
+
+Use this only for local generated build outputs.
+
+---
+
+## 13. Before Opening a Pull Request
+
+Check Git status from the repository root:
+
+```bash
+cd openamr-platform-sw
+git status
+```
+
+Make sure generated folders are not staged:
+
+```bash
+git status --ignored
+```
+
+Build from `ros2/`:
+
+```bash
+cd ros2
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+```
+
+For docking or simulation changes, run at least one launch smoke test:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+Commit with DCO sign-off:
+
+```bash
+git commit -s -m "Describe the change"
+```
+
+---
+
+## 14. Common Setup Problems
+
+### Package Not Found
+
+Example:
+
+```text
+package 'openamrobot_docking' not found
+```
+
+Usually the workspace was not sourced.
+
+Fix:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+```
+
+### Wrong Build Directory
+
+If `colcon build` was run from the repository root, build folders may appear in the wrong place.
+
+Correct build location:
+
+```bash
+openamr-platform-sw/ros2/
+```
+
+### Docking Node Exits or Nav2 Action Fails
+
+Check CycloneDDS:
+
+```bash
+echo $RMW_IMPLEMENTATION
+```
+
+Expected:
+
+```text
+rmw_cyclonedds_cpp
+```
+
+Set it if missing:
+
+```bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+### Gazebo or RViz Does Not Open
+
+Check that you are on a machine with graphical support.
+
+For headless testing:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+### Build Fails After Switching Branches
+
+Clean generated outputs and rebuild:
+
+```bash
+cd openamr-platform-sw/ros2
+rm -rf build install log
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+```
+
+---
+
+## 15. Quick Command Summary
+
+Fresh setup:
+
+```bash
+git clone https://github.com/openAMRobot/openamr-platform-sw.git
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+Every new terminal:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+Dock test:
+
+```bash
+ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
+```

--- a/docs/getting_started/GIT_GUIDE.md
+++ b/docs/getting_started/GIT_GUIDE.md
@@ -1,0 +1,911 @@
+# Git and GitHub Guide for Beginners
+
+This guide explains how to use Git and GitHub for this project, starting from a fork of the main repository:
+
+```text
+https://github.com/openAMRobot/openamr-platform-sw
+```
+
+It is written for beginners. You do not need to understand every command on the first day. Start with the basic workflow, then come back to the other sections when you need them.
+
+---
+
+## 1. What Git and GitHub Do
+
+**Git** is the tool on your computer that tracks file changes.
+
+**GitHub** is the website that stores a copy of the project online and helps people collaborate.
+
+Important words:
+
+| Word | Meaning |
+|---|---|
+| Repository, or repo | A project folder tracked by Git |
+| Commit | A saved snapshot of your changes |
+| Branch | A separate line of work |
+| `main` | The main branch of the project |
+| Fork | Your own GitHub copy of someone else's repository |
+| Clone | A local copy of a repository on your computer |
+| Remote | A GitHub repository connected to your local repo |
+| Pull request, or PR | A request to merge your changes into another repository |
+| Upstream | The original repository you forked from |
+| Origin | Usually your fork on GitHub |
+
+For this project:
+
+| Name | Repository |
+|---|---|
+| Upstream | `https://github.com/openAMRobot/openamr-platform-sw.git` |
+| Origin | Your fork, for example `https://github.com/YOUR_USERNAME/openamr-platform-sw.git` |
+
+---
+
+## 2. Install and Configure Git
+
+Check whether Git is installed:
+
+```bash
+git --version
+```
+
+If it is not installed on Ubuntu:
+
+```bash
+sudo apt update
+sudo apt install git
+```
+
+Configure your name and email. These appear in commits:
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "your-email@example.com"
+```
+
+Recommended beginner-friendly settings:
+
+```bash
+git config --global init.defaultBranch main
+git config --global pull.rebase false
+git config --global core.editor nano
+```
+
+Check your settings:
+
+```bash
+git config --list
+```
+
+---
+
+## 3. Fork the Main Repository on GitHub
+
+1. Open the main repository in your browser:
+
+   ```text
+   https://github.com/openAMRobot/openamr-platform-sw
+   ```
+
+2. Click **Fork** in the top-right corner.
+
+3. Choose your GitHub account.
+
+4. Keep the repository name as:
+
+   ```text
+   openamr-platform-sw
+   ```
+
+5. Make sure the fork is created from the `main` branch.
+
+After this, you will have your own copy:
+
+```text
+https://github.com/YOUR_USERNAME/openamr-platform-sw
+```
+
+Replace `YOUR_USERNAME` with your GitHub username in the commands below.
+
+---
+
+## 4. Clone Your Fork
+
+Clone your fork to your computer:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/openamr-platform-sw.git
+cd openamr-platform-sw
+```
+
+Check the current branch:
+
+```bash
+git branch
+```
+
+You should see `main`:
+
+```text
+* main
+```
+
+Check connected remotes:
+
+```bash
+git remote -v
+```
+
+At this point, `origin` should point to your fork.
+
+---
+
+## 5. Add the Original Repository as Upstream
+
+Your fork is not the original project. Add the original repository as `upstream`:
+
+```bash
+git remote add upstream https://github.com/openAMRobot/openamr-platform-sw.git
+```
+
+If Git says `remote upstream already exists`, update it instead:
+
+```bash
+git remote set-url upstream https://github.com/openAMRobot/openamr-platform-sw.git
+```
+
+Check again:
+
+```bash
+git remote -v
+```
+
+You should see something like:
+
+```text
+origin    https://github.com/YOUR_USERNAME/openamr-platform-sw.git (fetch)
+origin    https://github.com/YOUR_USERNAME/openamr-platform-sw.git (push)
+upstream  https://github.com/openAMRobot/openamr-platform-sw.git (fetch)
+upstream  https://github.com/openAMRobot/openamr-platform-sw.git (push)
+```
+
+Simple meaning:
+
+- `origin` is your fork.
+- `upstream` is the main OpenAMRobot repository.
+
+---
+
+## 6. The Most Important Rule
+
+Do not do feature work directly on `main`.
+
+Keep `main` clean and updated from the original repository. Create a new branch for every task.
+
+Good branch names:
+
+```text
+docs/git-guide
+fix/docking-launch-delay
+feature/navigation-map
+test/apriltag-detection
+```
+
+---
+
+## 7. Basic Daily Workflow
+
+Start from `main`:
+
+```bash
+git switch main
+```
+
+Update your local `main` from upstream:
+
+```bash
+git fetch upstream
+git pull upstream main
+```
+
+Push the updated `main` to your fork:
+
+```bash
+git push origin main
+```
+
+Create a new branch:
+
+```bash
+git switch -c docs/my-change
+```
+
+Make your changes in the files.
+
+Check what changed:
+
+```bash
+git status
+```
+
+See the exact text changes:
+
+```bash
+git diff
+```
+
+Stage the files you want to commit:
+
+```bash
+git add path/to/file
+```
+
+Or stage all changed files:
+
+```bash
+git add .
+```
+
+Commit your changes:
+
+```bash
+git commit -m "Add beginner Git guide"
+```
+
+Push your branch to your fork:
+
+```bash
+git push -u origin docs/my-change
+```
+
+Then open GitHub. It will usually show a button to create a pull request.
+
+---
+
+## 8. Create a Pull Request
+
+A pull request asks the maintainers to review and merge your branch.
+
+On GitHub:
+
+1. Go to your fork:
+
+   ```text
+   https://github.com/YOUR_USERNAME/openamr-platform-sw
+   ```
+
+2. Click **Compare & pull request**.
+
+3. Check the target repository and branch:
+
+   ```text
+   base repository: openAMRobot/openamr-platform-sw
+   base branch: main
+   ```
+
+4. Check your source branch:
+
+   ```text
+   head repository: YOUR_USERNAME/openamr-platform-sw
+   compare branch: your-branch-name
+   ```
+
+5. Write a clear title.
+
+6. Explain what you changed and why.
+
+7. Submit the pull request.
+
+Good PR title examples:
+
+```text
+Add beginner Git guide
+Fix docking launch delay parameter
+Update Nav2 simulation quickstart
+```
+
+---
+
+## 9. Keep Your Fork Updated
+
+The original repository may change while you are working. Update your fork often.
+
+Update local `main`:
+
+```bash
+git switch main
+git fetch upstream
+git pull upstream main
+```
+
+Push those updates to your fork:
+
+```bash
+git push origin main
+```
+
+If you have a feature branch and want the latest `main` changes in it:
+
+```bash
+git switch your-branch-name
+git merge main
+```
+
+If Git reports conflicts, see the conflict section below.
+
+---
+
+## 10. Common Git Commands
+
+### Check Status
+
+```bash
+git status
+```
+
+Use this often. It tells you:
+
+- Which branch you are on.
+- Which files changed.
+- Which files are staged.
+- Whether you need to commit or push.
+
+### See Branches
+
+```bash
+git branch
+```
+
+See local and remote branches:
+
+```bash
+git branch -a
+```
+
+### Create and Switch to a Branch
+
+```bash
+git switch -c new-branch-name
+```
+
+### Switch Branches
+
+```bash
+git switch branch-name
+```
+
+### See Commit History
+
+```bash
+git log --oneline
+```
+
+More detailed:
+
+```bash
+git log --oneline --graph --decorate --all
+```
+
+### See File Changes
+
+```bash
+git diff
+```
+
+See staged changes:
+
+```bash
+git diff --staged
+```
+
+### Stage Changes
+
+Stage one file:
+
+```bash
+git add path/to/file
+```
+
+Stage all changes:
+
+```bash
+git add .
+```
+
+### Commit Changes
+
+```bash
+git commit -m "Short description of the change"
+```
+
+Good commit messages:
+
+```text
+Add docking troubleshooting notes
+Fix typo in simulation quickstart
+Update Nav2 parameter documentation
+```
+
+Poor commit messages:
+
+```text
+changes
+fix
+stuff
+final
+```
+
+### Push Changes
+
+First push of a new branch:
+
+```bash
+git push -u origin branch-name
+```
+
+After the first push, you can usually use:
+
+```bash
+git push
+```
+
+### Pull Changes
+
+```bash
+git pull
+```
+
+For this fork workflow, it is clearer to be explicit:
+
+```bash
+git pull upstream main
+```
+
+### Fetch Changes
+
+```bash
+git fetch upstream
+```
+
+`fetch` downloads information from a remote but does not change your current files by itself.
+
+---
+
+## 11. Undo and Fix Mistakes
+
+Git is useful because mistakes can usually be fixed.
+
+### Unstage a File
+
+If you used `git add` but are not ready to commit:
+
+```bash
+git restore --staged path/to/file
+```
+
+### Discard Changes in One File
+
+Warning: this removes your local uncommitted edits in that file.
+
+```bash
+git restore path/to/file
+```
+
+Use this only when you are sure you do not want to keep those edits.
+
+### Fix the Last Commit Message
+
+```bash
+git commit --amend -m "Better commit message"
+```
+
+If you already pushed the commit, ask before amending. It can affect other people.
+
+### Add More Files to the Last Commit
+
+```bash
+git add path/to/file
+git commit --amend
+```
+
+Again, be careful if the commit was already pushed.
+
+### Create a Safe Backup Branch
+
+If you are unsure before trying something:
+
+```bash
+git branch backup/my-work
+```
+
+This creates a backup branch at your current commit.
+
+---
+
+## 12. Merge Conflicts
+
+A merge conflict happens when Git cannot automatically combine changes.
+
+Example:
+
+```bash
+git switch your-branch-name
+git merge main
+```
+
+If there is a conflict, Git will say which files need help.
+
+Check:
+
+```bash
+git status
+```
+
+Open the conflicted file. You may see markers like this:
+
+```text
+<<<<<<< HEAD
+Your branch version
+=======
+Other branch version
+>>>>>>> main
+```
+
+Edit the file so only the correct final content remains. Remove the conflict markers.
+
+Then stage and commit:
+
+```bash
+git add path/to/conflicted-file
+git commit
+```
+
+If you started a merge and want to cancel it:
+
+```bash
+git merge --abort
+```
+
+---
+
+## 13. Recommended Workflow for This Repository
+
+Use this full sequence whenever you start new work:
+
+```bash
+git switch main
+git fetch upstream
+git pull upstream main
+git push origin main
+git switch -c type/short-description
+```
+
+Make changes, then:
+
+```bash
+git status
+git diff
+git add .
+git commit -m "Describe the change"
+git push -u origin type/short-description
+```
+
+Open a pull request from:
+
+```text
+YOUR_USERNAME/type/short-description
+```
+
+into:
+
+```text
+openAMRobot/openamr-platform-sw:main
+```
+
+---
+
+## 14. Example: Documentation Change
+
+Create a branch:
+
+```bash
+git switch main
+git fetch upstream
+git pull upstream main
+git switch -c docs/update-quickstart
+```
+
+Edit the documentation file.
+
+Check changes:
+
+```bash
+git status
+git diff
+```
+
+Commit:
+
+```bash
+git add docs/getting_started/GIT_GUIDE.md
+git commit -m "Update Git guide"
+```
+
+Push:
+
+```bash
+git push -u origin docs/update-quickstart
+```
+
+Create a pull request on GitHub.
+
+---
+
+## 15. Example: Code Change
+
+Create a branch:
+
+```bash
+git switch main
+git fetch upstream
+git pull upstream main
+git switch -c fix/docking-parameter
+```
+
+Make the code change.
+
+Build or test the project as needed. For this repository, the ROS 2 workspace is inside `ros2/`:
+
+```bash
+cd ros2
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+```
+
+Return to the repository root if needed:
+
+```bash
+cd ..
+```
+
+Check and commit:
+
+```bash
+git status
+git diff
+git add path/to/changed-file
+git commit -m "Fix docking parameter handling"
+git push -u origin fix/docking-parameter
+```
+
+Create a pull request.
+
+---
+
+## 16. Files You Usually Should Not Commit
+
+Avoid committing generated files, build outputs, logs, and local settings.
+
+For this repository, after building ROS 2, these folders may appear inside `ros2/`:
+
+```text
+ros2/build/
+ros2/install/
+ros2/log/
+```
+
+These are local build outputs. They should usually not be committed.
+
+Before committing, always run:
+
+```bash
+git status
+```
+
+If you see files you did not intend to change, stop and check before committing.
+
+---
+
+## 17. GitHub Authentication
+
+When pushing over HTTPS, GitHub may ask you to authenticate. GitHub no longer accepts normal account passwords for Git operations.
+
+Use one of these methods:
+
+- GitHub CLI: `gh auth login`
+- A personal access token
+- SSH keys
+
+Beginner-friendly GitHub CLI setup:
+
+```bash
+sudo apt update
+sudo apt install gh
+gh auth login
+```
+
+Then follow the prompts.
+
+SSH setup is also good, but HTTPS with GitHub CLI is usually easier for beginners.
+
+---
+
+## 18. Useful Troubleshooting
+
+### "fatal: not a git repository"
+
+You are probably not inside the repository folder.
+
+Run:
+
+```bash
+pwd
+ls
+```
+
+Then go into the repo:
+
+```bash
+cd openamr-platform-sw
+```
+
+### "Permission denied" When Pushing
+
+You may be trying to push to the upstream repository instead of your fork.
+
+Check:
+
+```bash
+git remote -v
+```
+
+Push to your fork:
+
+```bash
+git push -u origin your-branch-name
+```
+
+### "Updates were rejected"
+
+Your fork or branch is behind the remote.
+
+For your own branch, first try:
+
+```bash
+git pull
+git push
+```
+
+For updating your fork's `main` from upstream:
+
+```bash
+git switch main
+git fetch upstream
+git pull upstream main
+git push origin main
+```
+
+### "Please commit your changes or stash them"
+
+You have uncommitted work, and Git does not want to overwrite it.
+
+Option 1: commit it:
+
+```bash
+git add .
+git commit -m "Save work in progress"
+```
+
+Option 2: stash it temporarily:
+
+```bash
+git stash
+```
+
+Bring stashed changes back:
+
+```bash
+git stash pop
+```
+
+### You Are on the Wrong Branch
+
+Check:
+
+```bash
+git branch
+git status
+```
+
+Switch:
+
+```bash
+git switch correct-branch-name
+```
+
+If you made changes on the wrong branch but have not committed yet:
+
+```bash
+git switch -c correct-new-branch-name
+```
+
+Your uncommitted changes usually move with you.
+
+---
+
+## 19. Command Cheat Sheet
+
+| Goal | Command |
+|---|---|
+| Check repo state | `git status` |
+| See current branch | `git branch` |
+| Create branch | `git switch -c branch-name` |
+| Switch branch | `git switch branch-name` |
+| See changed lines | `git diff` |
+| Stage one file | `git add path/to/file` |
+| Stage everything | `git add .` |
+| Commit | `git commit -m "Message"` |
+| First push of a branch | `git push -u origin branch-name` |
+| Push after first push | `git push` |
+| Fetch upstream | `git fetch upstream` |
+| Update from upstream main | `git pull upstream main` |
+| Show history | `git log --oneline` |
+| Unstage file | `git restore --staged path/to/file` |
+| Discard file changes | `git restore path/to/file` |
+| Stash changes | `git stash` |
+| Restore stash | `git stash pop` |
+| Abort merge | `git merge --abort` |
+
+---
+
+## 20. Beginner Checklist Before Opening a Pull Request
+
+Run these checks:
+
+```bash
+git status
+git diff --staged
+git log --oneline -5
+```
+
+Ask yourself:
+
+- Am I on the correct branch?
+- Did I commit only the files I meant to change?
+- Is my commit message clear?
+- Did I push to my fork, not upstream?
+- Does my pull request target `openAMRobot/openamr-platform-sw` and the `main` branch?
+
+For code changes, also build or test the relevant part of the project.
+
+---
+
+## 21. The Short Version
+
+For most contributions, this is the workflow:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/openamr-platform-sw.git
+cd openamr-platform-sw
+git remote add upstream https://github.com/openAMRobot/openamr-platform-sw.git
+
+git switch main
+git fetch upstream
+git pull upstream main
+git push origin main
+
+git switch -c docs/example-change
+
+# edit files
+
+git status
+git diff
+git add .
+git commit -m "Describe the change"
+git push -u origin docs/example-change
+```
+
+Then create a pull request on GitHub from your branch into:
+
+```text
+openAMRobot/openamr-platform-sw:main
+```

--- a/docs/getting_started/TESTING_GUIDE.md
+++ b/docs/getting_started/TESTING_GUIDE.md
@@ -1,0 +1,515 @@
+# Testing Guide
+
+This guide explains how to test changes in `openamr-platform-sw` before opening a pull request.
+
+The project is a ROS 2 robotics stack, so testing has several levels:
+
+- documentation checks
+- package builds
+- package tests
+- launch smoke tests
+- simulation behavior checks
+- docking-specific checks
+
+Use the smallest test set that matches your change, but always record what you ran in the pull request.
+
+---
+
+## 1. Before You Start
+
+Use Ubuntu 24.04 with ROS 2 Jazzy and Gazebo Harmonic.
+
+From the ROS 2 workspace:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+If the workspace has already been built:
+
+```bash
+source install/setup.bash
+```
+
+If `install/setup.bash` does not exist, build first:
+
+```bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+Check that the project packages are visible:
+
+```bash
+ros2 pkg list | grep openamrobot
+```
+
+Expected packages include:
+
+```text
+openamrobot_description
+openamrobot_docking
+openamrobot_gazebo
+openamrobot_nav2
+```
+
+---
+
+## 2. Choose the Right Test Level
+
+| Change type | Minimum recommended checks |
+|---|---|
+| Documentation only | Read the changed docs, check links/commands, run `git diff --check` |
+| Git/contributing docs | Check examples use the right repo, branch, DCO, and PR target |
+| Package README/docs | Build the related package if commands or package names changed |
+| Launch files | Build, source, run the affected launch smoke test |
+| URDF/xacro or meshes | Build, launch Gazebo, confirm robot spawns and TF exists |
+| Gazebo bridge/worlds | Build, launch Gazebo, check `/clock`, `/scan`, `/odom`, `/rgb_image`, `/cmd_vel` |
+| Nav2 config/maps | Build, launch Gazebo + Nav2, send or inspect a navigation goal |
+| Docking code/config | Build, launch full stack, trigger dock and undock |
+| C++ node changes | Build package, run package tests, run launch that uses the node |
+| Python node changes | Build package, run package tests if available, run launch that uses the script |
+
+---
+
+## 3. Documentation Checks
+
+For documentation-only changes, run from the repository root:
+
+```bash
+git status
+git diff --check
+```
+
+Review the changed files:
+
+```bash
+git diff
+```
+
+Check:
+
+- links point to real files
+- commands use the correct workspace path: `openamr-platform-sw/ros2`
+- commands source ROS 2 before ROS commands
+- commands source `install/setup.bash` after building
+- generated folders such as `build/`, `install/`, and `log/` are not committed
+
+For docs that mention topics or launch files, verify names against the repo:
+
+```bash
+find ros2/src -path "*launch*" -type f
+find ros2/src -name package.xml
+```
+
+---
+
+## 4. Build Checks
+
+Build the full current simulation stack:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+Build only one package:
+
+```bash
+colcon build --symlink-install --packages-select openamrobot_nav2
+```
+
+Build a package and everything needed up to it:
+
+```bash
+colcon build --symlink-install --packages-up-to openamrobot_docking
+```
+
+Use `--packages-up-to openamrobot_docking` for most docking, simulation, and launch-composition changes.
+
+---
+
+## 5. Package Tests
+
+Run all available package tests:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+colcon test
+colcon test-result --verbose
+```
+
+Run tests for one package:
+
+```bash
+colcon test --packages-select openamrobot_nav2
+colcon test-result --verbose
+```
+
+Run tests for the packages that currently include Python lint/test files:
+
+```bash
+colcon test --packages-select openamrobot_description openamrobot_gazebo openamrobot_nav2
+colcon test-result --verbose
+```
+
+Current test coverage:
+
+| Package | Current test type |
+|---|---|
+| `openamrobot_description` | Python package lint tests: copyright, flake8, pep257 |
+| `openamrobot_gazebo` | Python package lint tests: copyright, flake8, pep257 |
+| `openamrobot_nav2` | Python package lint tests: copyright, flake8, pep257 |
+| `openamrobot_docking` | Build coverage for C++ node and installed Python scripts; no dedicated test files yet |
+
+If `colcon test` fails, inspect:
+
+```bash
+colcon test-result --verbose
+```
+
+Then fix the failure before opening the PR, or explain clearly why the failure is unrelated.
+
+---
+
+## 6. Launch Smoke Tests
+
+Launch smoke tests prove that the main runtime layers still start.
+
+Use a sourced terminal:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+### One-Command Simulation Smoke Test
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+On slower machines:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py nav2_delay:=10 docking_delay:=22
+```
+
+Headless mode:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+Expected:
+
+- Gazebo starts or headless server starts.
+- Robot spawns.
+- `/clock`, `/scan`, `/odom`, `/tf`, and `/rgb_image` appear.
+- Nav2 starts after the configured delay.
+- Docking layer starts after Nav2.
+- No package lookup errors appear.
+
+### Three-Layer Smoke Test
+
+Use three sourced terminals.
+
+Terminal 1:
+
+```bash
+ros2 launch openamrobot_gazebo gz_simulator.launch.py
+```
+
+Terminal 2:
+
+```bash
+ros2 launch openamrobot_nav2 sim_bringup_launch.py
+```
+
+Terminal 3:
+
+```bash
+ros2 launch openamrobot_docking openamrobot_docking.launch.py
+```
+
+Expected:
+
+- Gazebo owns `/clock` and sensor topics.
+- Nav2 localizes on the map.
+- Docking starts AprilTag detection and the dock trigger node.
+
+---
+
+## 7. Runtime Topic Checks
+
+After launching the simulation, check core topics:
+
+```bash
+ros2 topic list
+ros2 topic echo /clock --once
+ros2 topic echo /scan --once
+ros2 topic echo /odom --once
+ros2 topic info /cmd_vel
+```
+
+Check robot model and static transforms:
+
+```bash
+ros2 topic echo /robot_description --once --qos-durability transient_local
+ros2 topic echo /tf_static --once --qos-durability transient_local
+```
+
+Check TF:
+
+```bash
+ros2 run tf2_ros tf2_echo map base_link
+ros2 run tf2_ros tf2_echo base_link camera_optical_frame
+```
+
+Check Nav2 action servers:
+
+```bash
+ros2 action list
+```
+
+Expected action:
+
+```text
+/navigate_to_pose
+```
+
+---
+
+## 8. Gazebo and Bridge Checks
+
+Use these checks after Gazebo is running.
+
+Check sensor topics:
+
+```bash
+ros2 topic echo /scan --once
+ros2 topic hz /rgb_image
+ros2 topic echo /odom --once
+```
+
+Check the velocity command bridge:
+
+```bash
+ros2 topic info /cmd_vel
+```
+
+The Gazebo bridge should be connected to `/cmd_vel`.
+
+Manual movement test:
+
+```bash
+ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.1}}" --once
+```
+
+Expected:
+
+- Robot moves forward briefly in Gazebo.
+- `/odom` changes.
+
+Use a small velocity and stop the test if the robot behaves unexpectedly.
+
+---
+
+## 9. Navigation Checks
+
+After Gazebo and Nav2 are running:
+
+```bash
+ros2 action list
+ros2 topic echo /map --once --qos-durability transient_local
+ros2 run tf2_ros tf2_echo map base_link
+```
+
+In RViz:
+
+- fixed frame should be `map`
+- robot should appear on the map
+- lidar scan should line up with the map
+- a simple 2D goal should produce a plan
+
+If testing without RViz, check that `/navigate_to_pose` exists and Nav2 logs show active lifecycle nodes.
+
+---
+
+## 10. Docking Checks
+
+After the full stack is running, trigger docking:
+
+```bash
+ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
+```
+
+Expected:
+
+- `dock_trigger.py` receives the trigger.
+- Phase 1 sends a Nav2 goal to the staging pose.
+- AprilTag detections are available.
+- The robot aligns and approaches the dock.
+
+Check AprilTag topics:
+
+```bash
+ros2 topic hz /rgb_image
+ros2 topic hz /camera_info
+ros2 topic hz /camera_info_synced
+ros2 topic echo /apriltag/detections --once
+```
+
+Check dock pose:
+
+```bash
+ros2 topic echo /detected_dock_pose --once
+ros2 run tf2_ros tf2_echo map charging_dock_apriltag
+```
+
+Test undock:
+
+```bash
+ros2 topic pub /undock_robot std_msgs/msg/Bool "{data: true}" --once
+```
+
+Expected:
+
+- Robot reverses away from the dock.
+- Robot rotates to face away from the dock.
+
+For deeper docking diagnostics, see:
+
+```text
+ros2/src/openamrobot_docking/docs/09_troubleshooting.md
+```
+
+---
+
+## 11. What to Test by Change Area
+
+### Documentation Change
+
+Run:
+
+```bash
+git diff --check
+```
+
+Also manually review changed commands, links, and package names.
+
+### Robot Description Change
+
+Run:
+
+```bash
+colcon build --symlink-install --packages-select openamrobot_description
+colcon test --packages-select openamrobot_description
+colcon test-result --verbose
+```
+
+Then launch Gazebo and confirm the robot spawns.
+
+### Gazebo Change
+
+Run:
+
+```bash
+colcon build --symlink-install --packages-up-to openamrobot_gazebo
+ros2 launch openamrobot_gazebo gz_simulator.launch.py
+```
+
+Check:
+
+```bash
+ros2 topic echo /clock --once
+ros2 topic echo /scan --once
+ros2 topic echo /odom --once
+ros2 topic info /cmd_vel
+```
+
+### Nav2 Change
+
+Run:
+
+```bash
+colcon build --symlink-install --packages-up-to openamrobot_nav2
+colcon test --packages-select openamrobot_nav2
+colcon test-result --verbose
+ros2 launch openamrobot_nav2 sim_bringup_launch.py
+```
+
+Check `/navigate_to_pose`, `/map`, and `map -> base_link`.
+
+### Docking Change
+
+Run:
+
+```bash
+colcon build --symlink-install --packages-up-to openamrobot_docking
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+Then trigger:
+
+```bash
+ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
+ros2 topic pub /undock_robot std_msgs/msg/Bool "{data: true}" --once
+```
+
+---
+
+## 12. Pull Request Test Plan
+
+Every pull request should include a test plan.
+
+Good examples:
+
+```text
+## Test plan
+
+- Ran `git diff --check`
+- Built from `ros2/` with `colcon build --symlink-install --packages-up-to openamrobot_docking`
+- Ran `colcon test --packages-select openamrobot_description openamrobot_gazebo openamrobot_nav2`
+- Launched `ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false`
+- Triggered docking with `/dock_trigger`; robot reached staging and started AprilTag alignment
+```
+
+For documentation-only changes:
+
+```text
+## Test plan
+
+- Ran `git diff --check`
+- Manually reviewed links and commands in the changed docs
+```
+
+If you did not run a test, say so and explain why:
+
+```text
+## Test plan
+
+- Not run: simulation smoke test requires Gazebo display access
+```
+
+---
+
+## 13. Common Testing Mistakes
+
+Avoid these:
+
+- running `colcon build` from the repository root instead of `ros2/`
+- forgetting `source /opt/ros/jazzy/setup.bash`
+- forgetting `source install/setup.bash` after building
+- running ROS commands without `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`
+- testing only the package build but not the launch file that uses it
+- committing generated folders such as `ros2/build/`, `ros2/install/`, or `ros2/log/`
+- opening a PR without a test plan
+

--- a/docs/getting_started/TROUBLESHOOTING.md
+++ b/docs/getting_started/TROUBLESHOOTING.md
@@ -1,0 +1,717 @@
+# Troubleshooting Guide
+
+This guide helps diagnose common problems while setting up, building, running, and contributing to `openamr-platform-sw`.
+
+For deep docking-specific diagnostics, also see:
+
+```text
+ros2/src/openamrobot_docking/docs/09_troubleshooting.md
+```
+
+Start with the quick checks below, then use the section that matches your symptom.
+
+---
+
+## 1. Quick Checks
+
+Run these first from the repository root:
+
+```bash
+pwd
+git status
+```
+
+Then check the ROS 2 workspace:
+
+```bash
+cd ros2
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+echo $ROS_DISTRO
+echo $RMW_IMPLEMENTATION
+ros2 pkg list | grep openamrobot
+```
+
+Expected:
+
+```text
+jazzy
+rmw_cyclonedds_cpp
+```
+
+Expected packages include:
+
+```text
+openamrobot_description
+openamrobot_docking
+openamrobot_gazebo
+openamrobot_nav2
+```
+
+If these checks fail, fix the setup before debugging higher-level launch or docking behavior.
+
+---
+
+## 2. Quick Symptom Table
+
+| Symptom | Likely cause | First fix |
+|---|---|---|
+| `package 'openamrobot_...' not found` | Workspace not sourced | `source install/setup.bash` from `ros2/` |
+| `colcon: command not found` | colcon extension missing | Install `python3-colcon-common-extensions` |
+| Build creates `build/ install/ log/` in repo root | Built from wrong folder | Build from `openamr-platform-sw/ros2` |
+| `dock_trigger.py` exits silently | FastDDS issue on Jazzy | Use CycloneDDS |
+| Gazebo/RViz does not open | No graphical display or headless machine | Use headless launch arguments |
+| Robot does not move | `/cmd_vel` not reaching Gazebo | Check `/cmd_vel` and bridge |
+| Nav2 does not plan | Costmap/localization not ready | Wait, check `/scan`, `/map`, `/tf` |
+| AprilTag is never detected | Camera/tag/config issue | Check image, camera info, tag family/size |
+| TF lookup errors | Missing transform or time mismatch | Check TF chain and `use_sim_time` |
+| PR DCO check fails | Commit missing sign-off | Amend commit with `--signoff` |
+| Push is rejected | Branch behind remote or rewritten commit | Pull or use `--force-with-lease` after amend |
+
+---
+
+## 3. Setup Problems
+
+### `colcon: command not found`
+
+Install colcon:
+
+```bash
+sudo apt update
+sudo apt install python3-colcon-common-extensions
+```
+
+Then source ROS 2 and try again:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+colcon --help
+```
+
+### ROS 2 Commands Are Not Found
+
+Symptom:
+
+```text
+ros2: command not found
+```
+
+Fix:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+```
+
+Check:
+
+```bash
+echo $ROS_DISTRO
+```
+
+Expected:
+
+```text
+jazzy
+```
+
+If `/opt/ros/jazzy/setup.bash` does not exist, ROS 2 Jazzy is not installed correctly.
+
+### Wrong Build Directory
+
+The ROS 2 workspace is:
+
+```text
+openamr-platform-sw/ros2/
+```
+
+Correct:
+
+```bash
+cd openamr-platform-sw/ros2
+colcon build --symlink-install
+```
+
+Incorrect:
+
+```bash
+cd openamr-platform-sw
+colcon build --symlink-install
+```
+
+If you accidentally built from the repository root, remove the generated root-level build outputs only after confirming they are not tracked:
+
+```bash
+git status
+```
+
+Generated folders should not be committed.
+
+### Missing ROS Dependencies
+
+If a build fails with a message like:
+
+```text
+Could not find a package configuration file provided by ...
+```
+
+Install the required packages from the README or run dependency installation from `ros2/`:
+
+```bash
+cd openamr-platform-sw/ros2
+rosdep install --from-paths src --ignore-src -r -y
+```
+
+If `rosdep` is not available:
+
+```bash
+sudo apt update
+sudo apt install python3-rosdep
+```
+
+---
+
+## 4. Build Problems
+
+### Build Fails After Switching Branches
+
+Old generated files can conflict with the new branch.
+
+From the ROS 2 workspace:
+
+```bash
+cd openamr-platform-sw/ros2
+rm -rf build install log
+source /opt/ros/jazzy/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+Only remove `build`, `install`, and `log` when they are local generated build outputs.
+
+### Package Builds but Launch Cannot Find It
+
+Symptom:
+
+```text
+package 'openamrobot_docking' not found
+```
+
+Fix:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+ros2 pkg list | grep openamrobot
+```
+
+If the package still does not appear, rebuild:
+
+```bash
+colcon build --symlink-install
+source install/setup.bash
+```
+
+### Build One Package While Debugging
+
+Build one package and its dependencies:
+
+```bash
+colcon build --symlink-install --packages-up-to openamrobot_docking
+```
+
+Build only one package:
+
+```bash
+colcon build --symlink-install --packages-select openamrobot_docking
+```
+
+Use `--packages-up-to` when you are unsure.
+
+---
+
+## 5. Sourcing Problems
+
+Every new terminal needs the environment again.
+
+From `openamr-platform-sw/ros2`:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+If you forget this, common symptoms are:
+
+- packages not found
+- launch files not found
+- topics missing
+- different terminals seeing different ROS graphs
+
+Check the current terminal:
+
+```bash
+echo $ROS_DISTRO
+echo $RMW_IMPLEMENTATION
+ros2 pkg list | grep openamrobot
+```
+
+---
+
+## 6. CycloneDDS Problems
+
+This project uses CycloneDDS for the current Jazzy docking workflow.
+
+Check:
+
+```bash
+echo $RMW_IMPLEMENTATION
+```
+
+Expected:
+
+```text
+rmw_cyclonedds_cpp
+```
+
+If it is empty or different:
+
+```bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+```
+
+Install CycloneDDS if needed:
+
+```bash
+sudo apt update
+sudo apt install ros-jazzy-rmw-cyclonedds-cpp
+```
+
+Make it permanent:
+
+```bash
+echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Important: set this in every terminal that runs ROS commands.
+
+---
+
+## 7. Launch Problems
+
+### Full Bringup Does Not Start Cleanly
+
+Run the full stack:
+
+```bash
+cd openamr-platform-sw/ros2
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ros2 launch openamrobot_docking bringup_sim.launch.py
+```
+
+On slower machines, widen startup delays:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py nav2_delay:=10 docking_delay:=22
+```
+
+For headless testing:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+### Layered Launch Debugging
+
+If the full launch is confusing, run layers separately.
+
+Terminal 1:
+
+```bash
+ros2 launch openamrobot_gazebo gz_simulator.launch.py
+```
+
+Terminal 2:
+
+```bash
+ros2 launch openamrobot_nav2 sim_bringup_launch.py
+```
+
+Terminal 3:
+
+```bash
+ros2 launch openamrobot_docking openamrobot_docking.launch.py
+```
+
+Start them in that order.
+
+### Old Processes After Ctrl-C
+
+If a relaunch behaves strangely, check for old processes:
+
+```bash
+ps aux | grep -E "gz|ros2|rviz|parameter_bridge"
+```
+
+Close old terminals first. If stale simulation processes remain, stop them before relaunching.
+
+---
+
+## 8. Gazebo and RViz Problems
+
+### Gazebo or RViz Does Not Open
+
+Make sure you are on a machine with graphical display support.
+
+For headless mode:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+### RViz Opens but Shows Nothing
+
+Wait around 10 seconds after launch. Some nodes need time to start.
+
+Check basic topics:
+
+```bash
+ros2 topic list
+ros2 topic echo /robot_description --once
+ros2 topic echo /tf_static --once
+```
+
+In RViz, set the fixed frame to:
+
+```text
+map
+```
+
+### Simulation Is Slow
+
+Use headless mode:
+
+```bash
+ros2 launch openamrobot_docking bringup_sim.launch.py gazebo_gui:=false use_rviz:=false
+```
+
+Close extra terminals that are echoing high-rate topics such as images or TF.
+
+---
+
+## 9. Robot Movement Problems
+
+### Robot Does Not Move
+
+Check whether `/cmd_vel` exists:
+
+```bash
+ros2 topic info /cmd_vel
+```
+
+Check whether velocity commands are being published:
+
+```bash
+ros2 topic echo /cmd_vel
+```
+
+Send a small manual command:
+
+```bash
+ros2 topic pub /cmd_vel geometry_msgs/msg/Twist "{linear: {x: 0.1}}" --once
+```
+
+If `/cmd_vel` has messages but the robot does not move in Gazebo, check the Gazebo bridge and diff-drive plugin.
+
+### Nav2 Moves in RViz but Robot Does Not Move in Gazebo
+
+This usually means the ROS-to-Gazebo bridge is not forwarding `/cmd_vel`.
+
+Check:
+
+```bash
+ros2 topic info /cmd_vel
+ros2 node list | grep bridge
+```
+
+The bridge should be subscribed to `/cmd_vel`.
+
+### Robot Moves but Drifts or Slides
+
+In simulation, this can come from contact, wheel, or spawn-height issues.
+
+Check the detailed docking troubleshooting and lessons learned:
+
+```text
+ros2/src/openamrobot_docking/docs/09_troubleshooting.md
+ros2/src/openamrobot_docking/docs/12_lessons_learned.md
+```
+
+---
+
+## 10. Navigation Problems
+
+### Nav2 Does Not Plan
+
+Check localization and sensor data:
+
+```bash
+ros2 topic list
+ros2 topic echo /scan --once
+ros2 topic echo /map --once
+ros2 run tf2_ros tf2_echo map base_link
+```
+
+If `/scan` is missing, the simulator or bridge layer is not providing lidar data.
+
+If `/map` is missing, localization or mapping is not ready.
+
+If `map -> base_link` is missing, Nav2 does not know where the robot is.
+
+### Goal Fails Immediately
+
+Wait for Nav2 lifecycle nodes to activate. Then check action servers:
+
+```bash
+ros2 action list
+```
+
+Expected action includes:
+
+```text
+/navigate_to_pose
+```
+
+If the action server is missing, restart the Nav2 layer and watch the terminal logs.
+
+---
+
+## 11. AprilTag and Docking Problems
+
+### Dock Trigger Does Nothing
+
+Check CycloneDDS first:
+
+```bash
+echo $RMW_IMPLEMENTATION
+```
+
+Expected:
+
+```text
+rmw_cyclonedds_cpp
+```
+
+Check that the trigger topic exists:
+
+```bash
+ros2 topic list | grep dock
+```
+
+Trigger docking:
+
+```bash
+ros2 topic pub /dock_trigger std_msgs/msg/Bool "{data: true}" --once
+```
+
+### AprilTag Is Not Detected
+
+Check camera topics:
+
+```bash
+ros2 topic list | grep camera
+ros2 topic hz /rgb_image
+ros2 topic hz /camera_info
+ros2 topic hz /camera_info_synced
+```
+
+Check detections:
+
+```bash
+ros2 topic list | grep apriltag
+ros2 topic echo /apriltag/detections --once
+```
+
+Common causes:
+
+- tag is not visible to the camera
+- wrong tag family
+- wrong tag size
+- camera image is not being bridged
+- `camera_info` is missing
+
+### Tag Is Detected but Dock Pose Is Missing
+
+Check TF:
+
+```bash
+ros2 run tf2_ros tf2_echo map charging_dock_apriltag
+```
+
+If this fails, check the full TF chain:
+
+```bash
+ros2 run tf2_ros tf2_echo map base_link
+ros2 run tf2_ros tf2_echo base_link camera_optical_frame
+```
+
+For full details, use:
+
+```text
+ros2/src/openamrobot_docking/docs/03_tf_frames.md
+ros2/src/openamrobot_docking/docs/09_troubleshooting.md
+```
+
+---
+
+## 12. TF and Time Problems
+
+### TF Lookup or Extrapolation Errors
+
+Common causes:
+
+- `use_sim_time` mismatch between nodes
+- missing transform
+- node started before `/clock`
+- stale process from an old launch
+
+Check `/clock`:
+
+```bash
+ros2 topic echo /clock --once
+```
+
+Check node time settings:
+
+```bash
+ros2 node list
+```
+
+Then inspect important transforms:
+
+```bash
+ros2 run tf2_ros tf2_echo map base_link
+ros2 run tf2_ros tf2_echo base_link camera_optical_frame
+```
+
+Generate a TF diagram:
+
+```bash
+ros2 run tf2_tools view_frames
+```
+
+This creates a `frames.pdf` in the current directory.
+
+---
+
+## 13. Git and Pull Request Problems
+
+### DCO Check Failed
+
+Each commit needs a sign-off line:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+For the latest commit:
+
+```bash
+git commit --amend --signoff --no-edit
+git push --force-with-lease origin your-branch-name
+```
+
+For new commits, use:
+
+```bash
+git commit -s -m "Describe the change"
+```
+
+### Review Required
+
+This is normal on protected branches.
+
+You cannot approve your own PR unless the repository rules allow it. A maintainer or reviewer with write access must approve it.
+
+### Push Updates Were Rejected
+
+Check your branch:
+
+```bash
+git status
+git branch
+```
+
+If your branch is behind the remote:
+
+```bash
+git pull
+git push
+```
+
+If you amended a commit, push with:
+
+```bash
+git push --force-with-lease origin your-branch-name
+```
+
+Use `--force-with-lease` only when you intentionally rewrote commits on your own branch.
+
+### Pushed to Fork Main but Upstream Did Not Change
+
+Pushing to your fork updates:
+
+```text
+https://github.com/YOUR_USERNAME/openamr-platform-sw
+```
+
+It does not directly update:
+
+```text
+https://github.com/openAMRobot/openamr-platform-sw
+```
+
+To update the upstream repository, open a pull request into:
+
+```text
+openAMRobot/openamr-platform-sw:main
+```
+
+---
+
+## 14. What to Include When Asking for Help
+
+Include the exact command you ran, the error message, and these outputs:
+
+```bash
+git status
+git log --oneline -5
+echo $ROS_DISTRO
+echo $RMW_IMPLEMENTATION
+ros2 pkg list | grep openamrobot
+```
+
+For runtime issues, also include:
+
+```bash
+ros2 topic list
+ros2 node list
+ros2 action list
+```
+
+For TF issues:
+
+```bash
+ros2 run tf2_ros tf2_echo map base_link
+ros2 run tf2_ros tf2_echo base_link camera_optical_frame
+```
+
+For docking-specific issues, include the launch command and the relevant logs from:
+
+```text
+ros2/src/openamrobot_docking/docs/09_troubleshooting.md
+```


### PR DESCRIPTION
## Summary

- Add a beginner-friendly Git and GitHub guide under `docs/getting_started/`
- Explain how to fork `openAMRobot/openamr-platform-sw`, clone a fork, add `upstream`, create branches, commit, push, and open pull requests
- Include common Git commands, troubleshooting, merge conflict basics, and safe undo commands
- Link the new guide from the main README

## Testing

- Not run; documentation-only change