### PR TITLE
AprilTag docking: 3-tag bundle, odom-anchored approach, robust undock

### DIFF
--- a/ros2/src/openamrobot_bringup/scripts/README.md
+++ b/ros2/src/openamrobot_bringup/scripts/README.md
@@ -1,0 +1,76 @@
+# Bring-up scripts
+
+## `log_splitter.py` — per-subsystem log topics
+
+The bring-up console is a firehose: every node's logs interleaved. This splits
+them so you can watch **one subsystem** at a time.
+
+### What it does
+
+Every ROS 2 node already publishes its logs to **`/rosout`**. `log_splitter`
+subscribes to `/rosout` and re-publishes each line as a `std_msgs/String` on a
+**per-node** topic under `/logs/`:
+
+```
+/rosout ──► log_splitter ──► /logs/dock_trigger
+                             /logs/camera
+                             /logs/controller_server
+                             /logs/apriltag_apriltag
+                             /logs/all           (everything, prefixed with the node)
+```
+
+Each line carries its level: `[INFO] …`, `[WARN] …`, `[ERROR] …`.
+The node name is sanitised into the topic suffix (dots in sub-logger names →
+`_`; namespaces keep their `/`).
+
+### Run it (on the Pi)
+
+It subscribes to `/rosout` **locally**, so run it on the Pi — no Wi-Fi cost. You
+then echo only the one topic you care about (from the Pi or the PC):
+
+```bash
+# on the Pi — dedicated terminal
+source /opt/ros/jazzy/setup.bash
+source ~/openamr-platform-sw/ros2/install/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export ROS_DOMAIN_ID=0
+python3 ~/openamr-platform-sw/ros2/src/openamrobot_bringup/scripts/log_splitter.py
+```
+
+Detach it so it survives the SSH session (recipe in memory `amr-pi-ros-commands`):
+
+```bash
+setsid bash -c 'source /opt/ros/jazzy/setup.bash; \
+  source ~/openamr-platform-sw/ros2/install/setup.bash; \
+  export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ROS_DOMAIN_ID=0; \
+  python3 ~/openamr-platform-sw/ros2/src/openamrobot_bringup/scripts/log_splitter.py \
+  > ~/log_splitter.log 2>&1' &
+```
+
+### Watch a subsystem (from the PC)
+
+```bash
+source /opt/ros/jazzy/setup.bash
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export ROS_DOMAIN_ID=0
+
+ros2 topic echo /logs/dock_trigger --field data      # docking only
+ros2 topic echo /logs/camera       --field data      # camera only
+ros2 topic echo /logs/apriltag_apriltag --field data # tag detector
+ros2 topic echo /logs/all          --field data      # everything, node-prefixed
+```
+
+List what's available (one topic appears per node that has logged):
+
+```bash
+ros2 topic list | grep '^/logs/'
+```
+
+### Notes
+
+- **Discovery, not history**: a `/logs/<node>` topic only appears once that node
+  has logged at least once since `log_splitter` started. Start it early.
+- **Volatile QoS**: `echo` shows lines from *now* on, not the backlog. For the
+  backlog, the bring-up console / `~/log_splitter.log` still have everything.
+- `log_splitter` skips its own logs (no feedback loop).
+- Not a `ros2 run` entry point — run it with `python3` as above.

--- a/ros2/src/openamrobot_bringup/scripts/log_splitter.py
+++ b/ros2/src/openamrobot_bringup/scripts/log_splitter.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Split /rosout into per-node topics under /logs/<node>.
+
+Every ROS 2 node already publishes its logs to /rosout. This node fans that
+firehose out into ONE topic per source, so you can watch a single subsystem
+instead of scrolling the whole bring-up console:
+
+    ros2 topic echo /logs/dock_trigger --field data     # docking
+    ros2 topic echo /logs/camera       --field data     # camera
+    ros2 topic echo /logs/controller_server --field data
+    ros2 topic echo /logs/all          --field data     # everything, node-prefixed
+
+Run it ON THE PI (it subscribes to /rosout locally — no Wi-Fi cost; you only
+echo the one topic you care about from the PC). Levels are prefixed in each line
+([INFO]/[WARN]/[ERROR]/…). Ctrl-C to stop.
+"""
+import re
+import rclpy
+from rclpy.node import Node
+from rcl_interfaces.msg import Log
+from std_msgs.msg import String
+
+LEVELS = {10: 'DEBUG', 20: 'INFO', 30: 'WARN', 40: 'ERROR', 50: 'FATAL'}
+
+
+def sanitize(name: str) -> str:
+    """Node/logger name -> valid topic suffix, keeping namespace hierarchy."""
+    n = (name or 'unknown').strip('/')
+    n = re.sub(r'[^A-Za-z0-9_/]', '_', n)   # dots (sub-loggers) -> _
+    return n or 'unknown'
+
+
+class LogSplitter(Node):
+    def __init__(self):
+        super().__init__('log_splitter')
+        self._pubs = {}
+        self._all = self.create_publisher(String, '/logs/all', 50)
+        self.create_subscription(Log, '/rosout', self._cb, 200)
+        self.get_logger().info(
+            'log_splitter up: /rosout -> /logs/<node>. '
+            'e.g. ros2 topic echo /logs/dock_trigger --field data')
+
+    def _pub_for(self, key: str):
+        p = self._pubs.get(key)
+        if p is None:
+            p = self.create_publisher(String, f'/logs/{key}', 50)
+            self._pubs[key] = p
+        return p
+
+    def _cb(self, msg: Log):
+        if msg.name == 'log_splitter':
+            return                                   # don't echo ourselves
+        lvl = LEVELS.get(msg.level, str(msg.level))
+        line = f'[{lvl}] {msg.msg}'
+        self._pub_for(sanitize(msg.name)).publish(String(data=line))
+        self._all.publish(String(data=f'[{msg.name}] {line}'))
+
+
+def main():
+    rclpy.init()
+    node = LogSplitter()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2/src/openamrobot_docking/CMakeLists.txt
+++ b/ros2/src/openamrobot_docking/CMakeLists.txt
@@ -26,6 +26,7 @@ install(TARGETS detected_dock_pose_publisher
 install(PROGRAMS
   scripts/camera_info_sync.py
   scripts/dock_trigger.py
+  scripts/apriltag_gate.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -19,7 +19,7 @@
     undock_trigger_topic: undock_robot
     goal_pose_topic: goal_pose
     goal_pose_forward_topic: goal_pose_nav
-    undock_reverse_distance: 1.0        # m — straight-line reverse before turning
+    undock_reverse_distance: 0.7        # m — straight-line reverse before turning
     undock_reverse_speed: 0.10          # m/s — reverse speed magnitude
 
     # Legacy fields read by opennav_docking::SimpleChargingDock — kept so the
@@ -35,12 +35,18 @@
     # docked (facing the tag).
     #
     # Sim layout (Raj's walled_world.sdf): robot spawns at world (0, 0) and
-    # AMCL initialises at map (0, 0) → map ≡ world. The AprilTag dock sits
-    # on the inner face of the +x wall at world (4.899, 0) with the tag
-    # normal pointing −x (SDF yaw = π). The robot approaches from the
-    # inside of the room facing +x, so the approach yaw is 0.
-    dock_pose_x: 1.730
-    dock_pose_y: 0.035
+    # Dock pose (tag-bundle CENTRE) in the map frame. MUST match the loaded map:
+    # the staging goal = (dock_pose_x − staging_distance, dock_pose_y) and has to
+    # land INSIDE the map, else the planner aborts ("Goal … was outside bounds").
+    # Measure it with the robot localised + facing the dock (3 tags visible):
+    #   ros2 run tf2_ros tf2_echo map charging_dock_tag_1  → Translation [x, y]
+    # and the tag's +z (matrix col 2) tells the approach yaw (points −x ⇒ yaw 0).
+    #
+    # piece_actuelle.yaml (map x: −6.58→1.97): tag measured at (1.362, 0.222),
+    # tag +z ≈ −x ⇒ robot docks facing +x ⇒ yaw 0. (Sim/old value was 4.899, 0 —
+    # that map spanned further +x; on this small map it fell off the edge.)
+    dock_pose_x: 1.362
+    dock_pose_y: 0.222
     dock_pose_yaw: 0.0
 
     # ─── Phase 1 — Nav2 NavigateToPose to the staging zone ───────────────────
@@ -67,13 +73,7 @@
     # Using the camera-frame angle rather than the running-average map
     # position means the centring is robust to solvePnP map-frame bias:
     # the tag is centred as it ACTUALLY appears in the image.
-    scan_rotation_speed: 0.30            # rad/s — open-loop search spin + clamp on centring.
-                                         # 0.17 (just above the 0.15 floor) was too close to
-                                         # the STATIC-friction limit to reliably START a
-                                         # spin-in-place from rest → the robot juddered in
-                                         # place and never searched ('tags not detected during
-                                         # scan'). 0.30 breaks stiction and sweeps; centring
-                                         # tolerance (±2°) still hit cleanly on the real robot.
+    scan_rotation_speed: 0.3            # rad/s — open-loop scan + clamp on centring
     scan_consecutive_target: 5          # centred frames in a row
     scan_centring_tolerance: 0.035      # rad ≈ 2° — tag must be this close to image centre
     scan_centring_kp: 1.0               # rad/s per rad of image-frame angle
@@ -117,28 +117,36 @@
     #     drive_yaw_max_omega saturation);
     #   - if the robot oscillates near the line, increase lookahead
     #     distance or decrease line_yaw_kp.
-    docking_distance: 0.25              # m — final CAMERA→tag depth at the dock.
-                                         # Camera-centric pipeline (docs §6) stops
-                                         # here. The tag leaves the FOV before this,
-                                         # so the last stretch is a blind straight
-                                         # advance (odometry-measured).
-    drive_speed: 0.12                   # m/s — forward speed (tapered near tag). Live-tunable.
-                                         # Turn radius = v / omega; the 0.15 rad/s motor floor
-                                         # means a slow v forces a tight correction turn that
-                                         # swings the camera off the bundle. 0.12 tuned on the
-                                         # real robot (2026-07-03): smooth curve onto the axis.
-    line_yaw_kp: 1.0                    # rad/s per rad of (desired_yaw − robot_yaw). Live-tunable.
-                                         # 1.0 (from 1.5) tuned on the real robot: less aggressive
-                                         # → no saturation to ±max on a small offset.
-    line_lookahead_distance: 1.0        # m — pure-pursuit lookahead on the dock-normal line.
-                                         # Live-tunable. Larger = gentler desired heading at a
-                                         # given lateral offset = smoother convergence (less
-                                         # zig-zag). 1.0 (from 0.3) tuned on the real robot: a
-                                         # 10 cm offset gives omega ~0.15 (was ~0.30 → oscillation).
-    drive_yaw_max_omega: 0.35           # rad/s clamp on omega. Widened from 0.2 so
-                                         # there is proportional room ABOVE the
-                                         # 0.15 rad/s rotation floor (min_turn_omega):
-                                         # 0.2 left only a 0.15->0.2 near-bang-bang band.
+    # ─── Final stop distance ─────────────────────────────────────────────────
+    # The forward LIDAR is the PRIMARY final stop (front-of-robot → dock): it is
+    # the reliable, depth-independent measurement. The camera depth is only a
+    # failsafe if the lidar misses the (thin) dock. Both default to 0.12 so the
+    # final gap is ~0.12 m whichever trigger fires. All three are live-tunable:
+    #   ros2 param set /dock_trigger stop_lidar_distance 0.12
+    stop_on_lidar: true                 # forward lidar = primary stop
+    stop_lidar_distance: 0.10           # m — FINAL stop: front (lidar) → dock. THE distance.
+    stop_lidar_arc_half_deg: 12.0       # ± half-angle of the forward stop cone
+    docking_distance: 0.10              # m — CAMERA→tag depth FAILSAFE (fires only if the
+                                         # lidar can't see the dock). Kept = stop_lidar_distance
+                                         # so it never pre-empts the lidar with a farther stop.
+    drive_speed: 0.05                   # m/s — forward speed (tapered near tag)
+    final_push_speed: 0.05              # m/s — floor of the near-dock taper = speed of the
+                                         # LAST cm. Raise (e.g. 0.12) to keep momentum over the
+                                         # dock's step/lip on a LOW battery. Live-tunable.
+    # Pure-pursuit gains — CALMED 2026-07-09 after huge near-dock oscillation.
+    # 2.5 / 0.3 (old) was more aggressive than the 2.0 / 0.3 already known to
+    # oscillate: high gain + short lookahead + drive_yaw_max_omega saturation =
+    # bang-bang limit cycle (robot swings → the base_link line swings in RViz →
+    # corrector chases). Both are LIVE-tunable (ros2 param set …) so re-dial at
+    # the field; these are just the stable defaults on relaunch.
+    line_yaw_kp: 1.2                    # rad/s per rad of (desired_yaw − robot_yaw)
+    line_lookahead_distance: 0.5        # m — pure-pursuit lookahead on the perpendicular line.
+                                         # Smaller = steeper desired heading at a
+                                         # given offset = faster (harsher) convergence.
+    turn_deadband: 0.09                 # rad/s — ignore corrections below this near the
+                                         # line (kills the end tremor from the omega floor).
+                                         # NOT live-tunable (read at init) → relaunch to apply.
+    drive_yaw_max_omega: 0.255          # rad/s clamp on omega (−15% from 0.3)
     drive_rate_hz: 20.0                 # Hz control loop frequency
 
     # Image-frame visual servo (used by Phase 5 NEAR regime, once the dock
@@ -151,31 +159,8 @@
     # the edge of the FOV), but the image-frame angle is self-consistent.
     # Keeping the tag centred in the image = aiming straight at the dock.
     # The low-pass filter rejects single-frame solvePnP spikes.
-    visual_servo_kp: 1.0                # rad/s per rad of desired_yaw (P term).
-                                         # 0.4 put omega below the 0.15 rad/s floor for
-                                         # any error < 21deg -> no reactivity. 1.0 gives
-                                         # 0.15 rad/s already at ~8.6deg. Tuned against the
-                                         # OLD raw-bearing signal — re-tune against
-                                         # desired_yaw (see visual_servo_lookahead below).
-    visual_servo_lookahead: 0.70        # m — fixed lookahead for desired_yaw = -atan2(lateral,
-                                         # lookahead), replacing the raw bearing atan2(X,Z)
-                                         # (2026-07-07 fix: Z shrinking through NEAR made the old
-                                         # bearing-only P-term intensify purely from getting
-                                         # closer, not from real drift). Defaulted equal to
-                                         # freeze_axis_distance so desired_yaw is continuous at
-                                         # the FAR->NEAR hand-over. Live-tunable.
-    visual_servo_kd: 0.2                # rad/s per rad/s — derivative damping so the
-                                         # livelier kp does not overshoot near contact.
-    visual_servo_filter_alpha: 0.6      # EMA on the bearing; higher = more reactive.
-    visual_servo_max_step: 0.35         # rad — reject single-frame solvePnP bearing jumps.
-    visual_lost_max_frames: 25          # frames tag-1 may stay lost (~1.25 s @20 Hz)
-                                         # before abort. While lost we COAST STRAIGHT
-                                         # (were aligned), so this is a coast budget,
-                                         # not a stop budget.
-    visual_align_deadband: 0.10         # rad (~5.7 deg). Hysteresis: drive straight
-                                         # when the bearing is within band, only engage
-                                         # a correction past it (release at 0.4x). Kills
-                                         # the left-right per-frame hunting.
+    visual_servo_kp: 0.6                # rad/s per rad of image-frame angle
+    visual_servo_filter_alpha: 0.2      # lower = more smoothing, slower response
 
     # Raj's Nav2 stack does NOT run a velocity_smoother that subscribes to
     # /cmd_vel_nav, so publishing there is a dead end (0 subscribers). We
@@ -186,8 +171,24 @@
 
     # ─── Tag detection topic ─────────────────────────────────────────────────
     detection_topic: /detected_dock_pose
-    # Maximum age (s) of a detection message before it is dropped as stale.
+    # Maximum age (s) of a tag TF before it is dropped as stale. Live-tunable
+    # (ros2 param set /dock_trigger detection_max_age …). Kept SMALL: when the
+    # camera loses a tag in the last centimetres, this is how long the NEAR loop
+    # keeps coasting on the stale, base_link-locked detection (marker + line slide
+    # WITH the robot, no odom re-correction) before it drops to the odom-frozen
+    # line (tier 3) that stays fixed on the dock. Was 1.5 s → ~15 cm of blind
+    # robot-locked drift; 0.5 s tolerates ~2 dropped frames at 4 Hz then hands to odom.
     detection_max_age: 1.5
+
+    # ─── Approach reference frame ────────────────────────────────────────────
+    # true (clean, 2026-07-09): the dock line lives in the ODOM frame at all
+    # times; fresh tags (looked up directly in odom, lag-correct) refine it,
+    # the centre tag alone re-anchors its position, no tag = coast on it via
+    # odometry. ONE frame, same pure-pursuit law throughout → the reference no
+    # longer swings with the robot (base_link) and there is no tier-boundary
+    # jump. false = legacy base_link/odom tier cascade. Live-tunable:
+    #   ros2 param set /dock_trigger unified_odom_line false
+    unified_odom_line: true
 
     # ─── Debug visualisation ─────────────────────────────────────────────────
     # Publish the perpendicular approach line (green LINE_STRIP) and the
@@ -219,29 +220,15 @@
     # Phase 5 hand-over: FAR (> this) average the 3-tag axis + pure-pursuit it;
     # NEAR (≤ this) freeze the axis and finish on the centre-tag visual
     # corrector. Freezing kills the close-range zig-zag (noisy near estimates).
-    freeze_axis_distance: 0.70         # m camera→centre tag. FAR→NEAR hand-over:
-                                         # ABOVE this the robot pure-pursuits the 3-tag
-                                         # dock normal (now in the ROBOT frame — see
-                                         # use_camera_frame_normal — so it aligns both
-                                         # laterally AND perpendicular to the dock);
-                                         # BELOW it the outer tags leave the FOV so it
-                                         # finishes on the centre-tag bearing corrector.
-                                         # Live-tunable (re-read each loop).
-    # Phase-5 FAR normal computed in the ROBOT frame (base_link) not the map frame.
-    # true = the final approach never reads the wobbly map (AMCL relocalisation jumps)
-    # or odometry drift; the dock axis is re-derived from the live camera TF every loop
-    # and pure-pursuit corrects lateral offset + approach heading. false = legacy line.
-    use_camera_frame_normal: true
-    # EMA weight for the live axis estimate. A plain cumulative mean freezes
-    # the early off-axis (wrong) estimates; the EMA keeps following the recent
-    # better ones. Higher = more reactive/noisier, lower = smoother/more stable.
-    # Weight ∝ depth/predock_distance (far = more trust, near = less — see
-    # dock_trigger.py, inverted 2026-07-07), capped in code. 0.40 was still
-    # visibly jittery/changing too much mid-course on real hardware
-    # (2026-07-07 user feedback: "la ligne est trop variable... qu'un petit peu
-    # à mi-course") — lowered to 0.12 for a much heavier, more stable average
-    # throughout the approach, not just near the dock.
-    axis_filter_alpha: 0.12
+    freeze_axis_distance: 0.70         # m camera→centre tag
+    # EMA weight for the live axis estimate (FAR regime). A plain cumulative
+    # mean freezes the early off-axis (wrong) estimates; the EMA keeps following
+    # the recent better ones. Higher = more reactive/noisier, lower = smoother.
+    # EMA weight grows as the robot gets closer (weight ∝ predock_distance/depth,
+    # capped), so the samples taken while advancing (nearer = more accurate)
+    # dominate the early far ones. Higher = reacts faster to new estimates
+    # (less smoothing); lower = smoother but slower to update.
+    axis_filter_alpha: 0.40
 
     # ─── Obstacle avoidance during drive phases ──────────────────────────────
     # The sequencer publishes cmd_vel straight to the robot, bypassing
@@ -267,7 +254,7 @@
     # Angles are interpreted in the LIDAR scan frame; assumes the LIDAR
     # is roughly aligned with base_link forward (a small lateral offset
     # does not change the cone meaningfully).
-    obstacle_check_enabled: false
+    obstacle_check_enabled: true
     # Use /scan_filtered (Nav2's scan_body_filter chain) — it chops the
     # angular sector where the LIDAR sees the robot's own enclosure (rear
     # ±40°), so close-range returns inside the kept sector are GENUINE

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -129,7 +129,7 @@
     docking_distance: 0.10              # m — CAMERA→tag depth FAILSAFE (fires only if the
                                          # lidar can't see the dock). Kept = stop_lidar_distance
                                          # so it never pre-empts the lidar with a farther stop.
-    drive_speed: 0.05                   # m/s — forward speed (tapered near tag)
+    drive_speed: 0.07                   # m/s — forward speed (tapered near tag). Live-tunable.
     final_push_speed: 0.05              # m/s — floor of the near-dock taper = speed of the
                                          # LAST cm. Raise (e.g. 0.12) to keep momentum over the
                                          # dock's step/lip on a LOW battery. Live-tunable.

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -124,9 +124,9 @@
     # final gap is ~0.12 m whichever trigger fires. All three are live-tunable:
     #   ros2 param set /dock_trigger stop_lidar_distance 0.12
     stop_on_lidar: true                 # forward lidar = primary stop
-    stop_lidar_distance: 0.10           # m — FINAL stop: front (lidar) → dock. THE distance.
+    stop_lidar_distance: 0.13           # m — FINAL stop: front (lidar) → dock. THE distance.
     stop_lidar_arc_half_deg: 12.0       # ± half-angle of the forward stop cone
-    docking_distance: 0.10              # m — CAMERA→tag depth FAILSAFE (fires only if the
+    docking_distance: 0.13              # m — CAMERA→tag depth FAILSAFE (fires only if the
                                          # lidar can't see the dock). Kept = stop_lidar_distance
                                          # so it never pre-empts the lidar with a farther stop.
     drive_speed: 0.10                   # m/s — forward speed (tapered near tag). Live-tunable.

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -151,10 +151,19 @@
     # the edge of the FOV), but the image-frame angle is self-consistent.
     # Keeping the tag centred in the image = aiming straight at the dock.
     # The low-pass filter rejects single-frame solvePnP spikes.
-    visual_servo_kp: 1.0                # rad/s per rad of image-frame bearing (P term).
+    visual_servo_kp: 1.0                # rad/s per rad of desired_yaw (P term).
                                          # 0.4 put omega below the 0.15 rad/s floor for
                                          # any error < 21deg -> no reactivity. 1.0 gives
-                                         # 0.15 rad/s already at ~8.6deg.
+                                         # 0.15 rad/s already at ~8.6deg. Tuned against the
+                                         # OLD raw-bearing signal — re-tune against
+                                         # desired_yaw (see visual_servo_lookahead below).
+    visual_servo_lookahead: 0.70        # m — fixed lookahead for desired_yaw = -atan2(lateral,
+                                         # lookahead), replacing the raw bearing atan2(X,Z)
+                                         # (2026-07-07 fix: Z shrinking through NEAR made the old
+                                         # bearing-only P-term intensify purely from getting
+                                         # closer, not from real drift). Defaulted equal to
+                                         # freeze_axis_distance so desired_yaw is continuous at
+                                         # the FAR->NEAR hand-over. Live-tunable.
     visual_servo_kd: 0.2                # rad/s per rad/s — derivative damping so the
                                          # livelier kp does not overshoot near contact.
     visual_servo_filter_alpha: 0.6      # EMA on the bearing; higher = more reactive.

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -19,7 +19,7 @@
     undock_trigger_topic: undock_robot
     goal_pose_topic: goal_pose
     goal_pose_forward_topic: goal_pose_nav
-    undock_reverse_distance: 1.5        # m — straight-line reverse before turning
+    undock_reverse_distance: 1.0        # m — straight-line reverse before turning
     undock_reverse_speed: 0.10          # m/s — reverse speed magnitude
 
     # Legacy fields read by opennav_docking::SimpleChargingDock — kept so the
@@ -39,8 +39,8 @@
     # on the inner face of the +x wall at world (4.899, 0) with the tag
     # normal pointing −x (SDF yaw = π). The robot approaches from the
     # inside of the room facing +x, so the approach yaw is 0.
-    dock_pose_x: 4.899
-    dock_pose_y: 0.0
+    dock_pose_x: 1.730
+    dock_pose_y: 0.035
     dock_pose_yaw: 0.0
 
     # ─── Phase 1 — Nav2 NavigateToPose to the staging zone ───────────────────
@@ -67,7 +67,13 @@
     # Using the camera-frame angle rather than the running-average map
     # position means the centring is robust to solvePnP map-frame bias:
     # the tag is centred as it ACTUALLY appears in the image.
-    scan_rotation_speed: 0.3            # rad/s — open-loop scan + clamp on centring
+    scan_rotation_speed: 0.30            # rad/s — open-loop search spin + clamp on centring.
+                                         # 0.17 (just above the 0.15 floor) was too close to
+                                         # the STATIC-friction limit to reliably START a
+                                         # spin-in-place from rest → the robot juddered in
+                                         # place and never searched ('tags not detected during
+                                         # scan'). 0.30 breaks stiction and sweeps; centring
+                                         # tolerance (±2°) still hit cleanly on the real robot.
     scan_consecutive_target: 5          # centred frames in a row
     scan_centring_tolerance: 0.035      # rad ≈ 2° — tag must be this close to image centre
     scan_centring_kp: 1.0               # rad/s per rad of image-frame angle
@@ -111,18 +117,28 @@
     #     drive_yaw_max_omega saturation);
     #   - if the robot oscillates near the line, increase lookahead
     #     distance or decrease line_yaw_kp.
-    docking_distance: 0.15              # m — final CAMERA→tag depth at the dock.
+    docking_distance: 0.25              # m — final CAMERA→tag depth at the dock.
                                          # Camera-centric pipeline (docs §6) stops
                                          # here. The tag leaves the FOV before this,
                                          # so the last stretch is a blind straight
                                          # advance (odometry-measured).
-    drive_speed: 0.05                   # m/s — forward speed (tapered near tag)
-    line_yaw_kp: 2.5                    # rad/s per rad of (desired_yaw − robot_yaw)
-    line_lookahead_distance: 0.3        # m — pure-pursuit lookahead on the perpendicular line.
-                                         # Smaller = steeper desired heading at
-                                         # a given offset = faster lateral
-                                         # convergence onto the line.
-    drive_yaw_max_omega: 0.3            # rad/s clamp on omega
+    drive_speed: 0.12                   # m/s — forward speed (tapered near tag). Live-tunable.
+                                         # Turn radius = v / omega; the 0.15 rad/s motor floor
+                                         # means a slow v forces a tight correction turn that
+                                         # swings the camera off the bundle. 0.12 tuned on the
+                                         # real robot (2026-07-03): smooth curve onto the axis.
+    line_yaw_kp: 1.0                    # rad/s per rad of (desired_yaw − robot_yaw). Live-tunable.
+                                         # 1.0 (from 1.5) tuned on the real robot: less aggressive
+                                         # → no saturation to ±max on a small offset.
+    line_lookahead_distance: 1.0        # m — pure-pursuit lookahead on the dock-normal line.
+                                         # Live-tunable. Larger = gentler desired heading at a
+                                         # given lateral offset = smoother convergence (less
+                                         # zig-zag). 1.0 (from 0.3) tuned on the real robot: a
+                                         # 10 cm offset gives omega ~0.15 (was ~0.30 → oscillation).
+    drive_yaw_max_omega: 0.35           # rad/s clamp on omega. Widened from 0.2 so
+                                         # there is proportional room ABOVE the
+                                         # 0.15 rad/s rotation floor (min_turn_omega):
+                                         # 0.2 left only a 0.15->0.2 near-bang-bang band.
     drive_rate_hz: 20.0                 # Hz control loop frequency
 
     # Image-frame visual servo (used by Phase 5 NEAR regime, once the dock
@@ -135,8 +151,22 @@
     # the edge of the FOV), but the image-frame angle is self-consistent.
     # Keeping the tag centred in the image = aiming straight at the dock.
     # The low-pass filter rejects single-frame solvePnP spikes.
-    visual_servo_kp: 0.6                # rad/s per rad of image-frame angle
-    visual_servo_filter_alpha: 0.2      # lower = more smoothing, slower response
+    visual_servo_kp: 1.0                # rad/s per rad of image-frame bearing (P term).
+                                         # 0.4 put omega below the 0.15 rad/s floor for
+                                         # any error < 21deg -> no reactivity. 1.0 gives
+                                         # 0.15 rad/s already at ~8.6deg.
+    visual_servo_kd: 0.2                # rad/s per rad/s — derivative damping so the
+                                         # livelier kp does not overshoot near contact.
+    visual_servo_filter_alpha: 0.6      # EMA on the bearing; higher = more reactive.
+    visual_servo_max_step: 0.35         # rad — reject single-frame solvePnP bearing jumps.
+    visual_lost_max_frames: 25          # frames tag-1 may stay lost (~1.25 s @20 Hz)
+                                         # before abort. While lost we COAST STRAIGHT
+                                         # (were aligned), so this is a coast budget,
+                                         # not a stop budget.
+    visual_align_deadband: 0.10         # rad (~5.7 deg). Hysteresis: drive straight
+                                         # when the bearing is within band, only engage
+                                         # a correction past it (release at 0.4x). Kills
+                                         # the left-right per-frame hunting.
 
     # Raj's Nav2 stack does NOT run a velocity_smoother that subscribes to
     # /cmd_vel_nav, so publishing there is a dead end (0 subscribers). We
@@ -180,7 +210,19 @@
     # Phase 5 hand-over: FAR (> this) average the 3-tag axis + pure-pursuit it;
     # NEAR (≤ this) freeze the axis and finish on the centre-tag visual
     # corrector. Freezing kills the close-range zig-zag (noisy near estimates).
-    freeze_axis_distance: 0.70         # m camera→centre tag
+    freeze_axis_distance: 0.70         # m camera→centre tag. FAR→NEAR hand-over:
+                                         # ABOVE this the robot pure-pursuits the 3-tag
+                                         # dock normal (now in the ROBOT frame — see
+                                         # use_camera_frame_normal — so it aligns both
+                                         # laterally AND perpendicular to the dock);
+                                         # BELOW it the outer tags leave the FOV so it
+                                         # finishes on the centre-tag bearing corrector.
+                                         # Live-tunable (re-read each loop).
+    # Phase-5 FAR normal computed in the ROBOT frame (base_link) not the map frame.
+    # true = the final approach never reads the wobbly map (AMCL relocalisation jumps)
+    # or odometry drift; the dock axis is re-derived from the live camera TF every loop
+    # and pure-pursuit corrects lateral offset + approach heading. false = legacy line.
+    use_camera_frame_normal: true
     # EMA weight for the live axis estimate (FAR regime). A plain cumulative
     # mean freezes the early off-axis (wrong) estimates; the EMA keeps following
     # the recent better ones. Higher = more reactive/noisier, lower = smoother.
@@ -214,7 +256,7 @@
     # Angles are interpreted in the LIDAR scan frame; assumes the LIDAR
     # is roughly aligned with base_link forward (a small lateral offset
     # does not change the cone meaningfully).
-    obstacle_check_enabled: true
+    obstacle_check_enabled: false
     # Use /scan_filtered (Nav2's scan_body_filter chain) — it chops the
     # angular sector where the LIDAR sees the robot's own enclosure (rear
     # ±40°), so close-range returns inside the kept sector are GENUINE

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -232,14 +232,16 @@
     # or odometry drift; the dock axis is re-derived from the live camera TF every loop
     # and pure-pursuit corrects lateral offset + approach heading. false = legacy line.
     use_camera_frame_normal: true
-    # EMA weight for the live axis estimate (FAR regime). A plain cumulative
-    # mean freezes the early off-axis (wrong) estimates; the EMA keeps following
-    # the recent better ones. Higher = more reactive/noisier, lower = smoother.
-    # EMA weight grows as the robot gets closer (weight ∝ predock_distance/depth,
-    # capped), so the samples taken while advancing (nearer = more accurate)
-    # dominate the early far ones. Higher = reacts faster to new estimates
-    # (less smoothing); lower = smoother but slower to update.
-    axis_filter_alpha: 0.40
+    # EMA weight for the live axis estimate. A plain cumulative mean freezes
+    # the early off-axis (wrong) estimates; the EMA keeps following the recent
+    # better ones. Higher = more reactive/noisier, lower = smoother/more stable.
+    # Weight ∝ depth/predock_distance (far = more trust, near = less — see
+    # dock_trigger.py, inverted 2026-07-07), capped in code. 0.40 was still
+    # visibly jittery/changing too much mid-course on real hardware
+    # (2026-07-07 user feedback: "la ligne est trop variable... qu'un petit peu
+    # à mi-course") — lowered to 0.12 for a much heavier, more stable average
+    # throughout the approach, not just near the dock.
+    axis_filter_alpha: 0.12
 
     # ─── Obstacle avoidance during drive phases ──────────────────────────────
     # The sequencer publishes cmd_vel straight to the robot, bypassing

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -254,7 +254,10 @@
     # Angles are interpreted in the LIDAR scan frame; assumes the LIDAR
     # is roughly aligned with base_link forward (a small lateral offset
     # does not change the cone meaningfully).
-    obstacle_check_enabled: true
+    # false = ignore obstacles during the drive phases — the dock IS the
+    # "obstacle" we drive onto, and the forward guard (0.6 m) kept aborting the
+    # approach. Now live-tunable: ros2 param set /dock_trigger obstacle_check_enabled …
+    obstacle_check_enabled: false
     # Use /scan_filtered (Nav2's scan_body_filter chain) — it chops the
     # angular sector where the LIDAR sees the robot's own enclosure (rear
     # ±40°), so close-range returns inside the kept sector are GENUINE

--- a/ros2/src/openamrobot_docking/config/dock_trigger.yaml
+++ b/ros2/src/openamrobot_docking/config/dock_trigger.yaml
@@ -129,7 +129,7 @@
     docking_distance: 0.10              # m — CAMERA→tag depth FAILSAFE (fires only if the
                                          # lidar can't see the dock). Kept = stop_lidar_distance
                                          # so it never pre-empts the lidar with a farther stop.
-    drive_speed: 0.07                   # m/s — forward speed (tapered near tag). Live-tunable.
+    drive_speed: 0.10                   # m/s — forward speed (tapered near tag). Live-tunable.
     final_push_speed: 0.05              # m/s — floor of the near-dock taper = speed of the
                                          # LAST cm. Raise (e.g. 0.12) to keep momentum over the
                                          # dock's step/lip on a LOW battery. Live-tunable.

--- a/ros2/src/openamrobot_docking/config/tags_36h11.yaml
+++ b/ros2/src/openamrobot_docking/config/tags_36h11.yaml
@@ -1,0 +1,33 @@
+/**:
+    ros__parameters:
+        image_transport: raw
+        family: 36h11
+        # size = side of the BLACK border square (NOT the whole printed panel).
+        # A 36h11 tag image is 10 modules wide with a 1-module quiet zone each side,
+        # so the black square is 8/10 of the printed panel width.
+        # ⚠️ REAL ROBOT: MEASURE your printed tag's black-square edge and set it here
+        # (e.g. a 0.10 m printed panel -> 0.08 m black square). Wrong size = wrong dock
+        # distance. Placeholder below assumes a 0.10 m panel.
+        size:  0.131
+        max_hamming: 0
+
+        detector:
+            threads: 3
+            decimate: 2.0       # detect quads on a half-res image (~4x faster) then
+                                # refine=True re-fits corners at full res. Fixes the
+                                # backlog: decimate 1.0 ran the 1280x720 quad detector
+                                # at ~8 Hz < camera 15 Hz -> queue built up -> 0.7 s+
+                                # detection latency (growing past detection_max_age ->
+                                # 'tag 1 lost'). Half-res keeps up -> ~1-frame latency.
+            blur: 0.0
+            refine: True
+            sharpening: 0.25
+            debug: False
+
+        pose_estimation_method: "pnp"
+
+        tag:
+            ids: [0, 1, 2]
+            frames: [charging_dock_tag_0, charging_dock_tag_1, charging_dock_tag_2]
+            # If the three tags differ in size, set per-tag sizes here; otherwise the
+            # global `size` above applies to all three.

--- a/ros2/src/openamrobot_docking/docs/00_overview.md
+++ b/ros2/src/openamrobot_docking/docs/00_overview.md
@@ -132,3 +132,4 @@ For exact install commands and the launch sequence, see [`01_quickstart.md`](01_
 | Learn from past mistakes | [`12_lessons_learned.md`](12_lessons_learned.md) |
 | Understand perception + how the line is built (and see it in RViz) | [`13_perception_and_line.md`](13_perception_and_line.md) |
 | Read the docking research: chargers, sensing methods, validation, failure modes, calibration | [`14_docking_research.md`](14_docking_research.md) |
+| Roll back the NEAR-field visual servo to before 2026-07-07 (superseded — kept for rollback) | [`15_legacy_near_approach.md`](15_legacy_near_approach.md) |

--- a/ros2/src/openamrobot_docking/docs/00_overview.md
+++ b/ros2/src/openamrobot_docking/docs/00_overview.md
@@ -132,4 +132,3 @@ For exact install commands and the launch sequence, see [`01_quickstart.md`](01_
 | Learn from past mistakes | [`12_lessons_learned.md`](12_lessons_learned.md) |
 | Understand perception + how the line is built (and see it in RViz) | [`13_perception_and_line.md`](13_perception_and_line.md) |
 | Read the docking research: chargers, sensing methods, validation, failure modes, calibration | [`14_docking_research.md`](14_docking_research.md) |
-| Roll back the NEAR-field visual servo to before 2026-07-07 (superseded — kept for rollback) | [`15_legacy_near_approach.md`](15_legacy_near_approach.md) |

--- a/ros2/src/openamrobot_docking/docs/09_troubleshooting.md
+++ b/ros2/src/openamrobot_docking/docs/09_troubleshooting.md
@@ -250,6 +250,20 @@ This depends on your `apriltag_ros` version's solvePnP convention. Verify by ech
   ros2 node list | grep dock_trigger
   ```
 
+#### **[real]** After a docking crash, the robot navigates with no collision layer
+
+During a dock, `dock_trigger` deactivates Nav2's `collision_monitor` (it otherwise
+fights `/cmd_vel`) and re-activates it — with retries and verification — when the
+maneuver ends. But if `dock_trigger` itself is **killed or crashes mid-dock**, nothing
+runs that restore, so the monitor stays **deactivated** and the robot keeps navigating
+with no reactive collision layer. Symptom: `dock_trigger` published the status
+`collision_monitor_down`, or it simply died. Restore it manually:
+
+```bash
+ros2 lifecycle set /collision_monitor activate
+ros2 lifecycle get /collision_monitor   # expect: active
+```
+
 ---
 
 ### 2.6 Simulation-specific

--- a/ros2/src/openamrobot_docking/docs/15_legacy_near_approach.md
+++ b/ros2/src/openamrobot_docking/docs/15_legacy_near_approach.md
@@ -1,0 +1,105 @@
+# NEAR-field visual servo — pre-2026-07-07 version (legacy — superseded)
+
+> ⚠️ **This document describes the Phase 5 NEAR-field corrector as it shipped before the
+> 2026-07-07 rewrite.** It is **kept for historical context and rollback reference** — it is
+> **not** the code running today, and nothing in `dock_trigger.py` reads this document.
+>
+> The FAR/NEAR hand-over structure (`freeze_axis_distance`) and the overall 7-phase sequencer
+> are unchanged — only the NEAR-field steering law described here was rewritten. For the
+> current implementation, see:
+> - [`13_perception_and_line.md`](13_perception_and_line.md) — perpendicular-line tracking and
+>   the FAR-regime axis estimate (unaffected by this change)
+> - [`05_parameters.md`](05_parameters.md) — current parameter meanings
+> - the in-code comments in `_final_visual_approach()` in
+>   [`scripts/dock_trigger.py`](../scripts/dock_trigger.py)
+>
+> **Exact rollback point:** the git tag `docking-legacy-pre-2026-07-07-near-approach` marks the
+> last commit before this rewrite started. To see the file as it was:
+> `git show docking-legacy-pre-2026-07-07-near-approach:ros2/src/openamrobot_docking/scripts/dock_trigger.py`.
+> To fully revert the NEAR corrector while keeping everything merged after it, `git revert` the
+> `feature/docking-near-approach` PR merge commit rather than hand-editing — the tag is there so
+> the exact starting point is never ambiguous even if that PR's branch is later deleted.
+
+---
+
+## Why this document exists
+
+The night of 2026-07-07, real-robot testing of the final approach (NEAR regime, camera→tag
+depth ≤ `freeze_axis_distance`, ~0.25–0.70 m) showed a large oscillation with poor reactivity in
+the last seconds before contact. Three real bugs were found and fixed (below). The fixes were
+validated on hardware ("c'est aligné") but only over a single evening with a battery that ran low
+by the end — this is a good rewrite, not a battle-tested one. This document lets a future session
+compare against the exact prior behaviour, or fall back to it wholesale, without having to dig
+through git log.
+
+---
+
+## The old NEAR steering law
+
+```python
+raw_angle = atan2(c1cam[0], c1cam[2])      # bearing to the centre tag, camera_optical_frame
+
+if filtered_angle is None:
+    filtered_angle = raw_angle
+    d_angle = 0.0
+elif abs(raw_angle - filtered_angle) > visual_servo_max_step:
+    d_angle = 0.0                          # solvePnP flicker — reject, coast on last
+else:
+    prev_angle = filtered_angle
+    filtered_angle = alpha * raw_angle + (1 - alpha) * filtered_angle
+    d_angle = (filtered_angle - prev_angle) / period     # <-- FIXED period, not real dt
+
+# hysteresis deadband (unchanged by the rewrite, still in the current code)
+if abs(filtered_angle) > deadband: correcting = True
+elif abs(filtered_angle) < 0.4 * deadband: correcting = False
+
+omega = -(kp * filtered_angle + kd * d_angle) if correcting else 0.0
+```
+
+Depth (`c1cam[2]`) was read only to decide the FAR→NEAR hand-over; the steering law itself never
+used it — a bearing-only PD controller on `atan2(X, Z)`.
+
+## The three bugs this had
+
+1. **Fixed-`period` derivative.** `d_angle` divided by the nominal control period (0.05 s)
+   instead of the real elapsed time since the last *valid* sample. AprilTag detections were
+   observed missing ~25% of frames in NEAR; every time a tag reappeared after a multi-frame gap,
+   the angle delta got divided by a `period` far smaller than the real elapsed time, inflating the
+   derivative term into a sharp corrective jerk exactly when the signal was staler, not fresher.
+
+2. **No depth compensation.** `atan2(X, Z)` mechanically grows for the *same physical lateral
+   error* as `Z` (depth) shrinks — the closer the robot gets, the more aggressively the same
+   1 cm of true offset reads as an angular error, so `kp` that was calm at 0.6 m became jumpy at
+   0.25 m without the robot's real position error changing.
+
+3. **No lookahead, no lateral-offset reasoning.** Because the law steered on `atan2(X, Z)`
+   directly rather than reasoning about a lateral offset against a fixed lookahead distance (as
+   the FAR regime already did with `line_lookahead_distance`), the NEAR and FAR regimes had
+   qualitatively different response curves — the hand-over between them was not smooth in gain
+   terms even though the position was continuous.
+
+## What replaced it (current code, 2026-07-07 onward)
+
+- Real elapsed time (`now - last_valid_t`) for the derivative, with the derivative explicitly
+  zeroed (not extrapolated) across a gap longer than ~2.5 control periods.
+- A fixed lookahead distance for the NEAR regime (mirroring the FAR regime's pure-pursuit),
+  so lateral offset — not raw bearing — drives the correction, removing the depth-dependent gain
+  blow-up.
+- Heavier axis smoothing and a stability-weighted average feeding the frozen dock-normal
+  reference carried across the FAR→NEAR hand-over via odometry.
+- `visual_servo_kp` / `visual_servo_kd` were re-tuned for the new signal — the old values (tuned
+  for the raw-bearing law) do not carry over.
+
+## What did **not** change
+
+- The FAR-regime pure-pursuit on the 3-tag averaged dock axis (`13_perception_and_line.md`).
+- The hysteresis deadband mechanism and the sigma-delta PWM actuation floor
+  (`_floor_omega` — a *different*, later attempt at a stiction fix on the *search scan*, not the
+  NEAR corrector, was tried and reverted the same night; see
+  `docs/2026-07-07-session-docking-corrector-rewrite.md` in the notes repo for that detail).
+- `stop_lidar_in_approach` semantics (only the module comment describing why it defaults to
+  `False` was corrected — it previously wrongly claimed AprilTag and the LiDAR driver shared a
+  process container).
+- The continuous-autofocus camera fix (`camera.launch.py`, `AfMode: 2`) is unrelated to this
+  steering law but shipped in the same session/PR — it fixes NEAR-field image blur, not the
+  oscillation described here.

--- a/ros2/src/openamrobot_docking/docs/README.md
+++ b/ros2/src/openamrobot_docking/docs/README.md
@@ -27,8 +27,10 @@ docs/
 ├── 11_changes_from_upstream.md     what this revision changes vs prior pipelines
 ├── 12_lessons_learned.md           decisions diary with rationale
 ├── 13_perception_and_line.md       what AprilTag gives us + how the line is built + RViz markers
-└── 14_docking_research.md          vendor-agnostic precision-docking research, validation,
-                                    failure modes, calibration, multi-dock
+├── 14_docking_research.md          vendor-agnostic precision-docking research, validation,
+│                                   failure modes, calibration, multi-dock
+└── 15_legacy_near_approach.md      legacy: the pre-2026-07-07 NEAR-field visual servo
+                                    (superseded by the dt-fix + depth-compensated version)
 ```
 
 ---
@@ -47,6 +49,7 @@ docs/
 | **Audit / understand a design choice** | `11_changes_from_upstream.md` + `12_lessons_learned.md` |
 | **Vendor / sensing research, validation plan, failure modes** | `14_docking_research.md` |
 | **Historical context (legacy single-tag pipeline)** | `08_legacy_sequencer.md` |
+| **Roll back the NEAR-field corrector to before 2026-07-07** | `15_legacy_near_approach.md` (+ git tag `docking-legacy-pre-2026-07-07-near-approach`) |
 
 ---
 

--- a/ros2/src/openamrobot_docking/launch/apriltag.launch.yml
+++ b/ros2/src/openamrobot_docking/launch/apriltag.launch.yml
@@ -1,0 +1,56 @@
+launch:
+# AprilTag detection on the REAL robot.
+#
+# Does NOT start a camera — the real camera (camera_ros / IMX708) is already
+# started by openamrobot_bringup/real_bringup.launch.py and publishes:
+#   /camera/image_raw      (raw image)
+#   /camera/camera_info    (this unit's calibrated intrinsics)
+#
+# We feed the RAW image straight to AprilTagNode together with the calibrated
+# camera_info (PnP uses the distortion model from camera_info). For maximum
+# accuracy you may insert an image_proc::RectifyNode and point apriltag at the
+# rectified image instead; raw is simpler and adequate for a centred dock tag.
+#
+# Publishes:
+#   /apriltag/detections  (apriltag_msgs/AprilTagDetectionArray)
+#   /tf  (camera_optical_frame -> charging_dock_tag_{0,1,2})
+#
+# Detector parameters (family, tag size, IDs, frame names) come from
+# config/tags_36h11.yaml  (set the printed tag size there!).
+
+# On-demand image gate: forwards /camera/image_raw -> /apriltag/image_in ONLY
+# when enabled (std_srvs/SetBool on /apriltag/set_enabled). Starts DISABLED so
+# apriltag_node receives nothing and idles at ~0% CPU until docking asks for it
+# (dock_trigger enables it at the staging zone, disables it when the sequence
+# ends). apriltag_node stays alive the whole time -> toggling is ~instant.
+# For standalone apriltag testing without dock_trigger, set start_enabled:=true
+# here or call the service by hand.
+- node:
+    pkg: openamrobot_docking
+    exec: apriltag_gate.py
+    name: apriltag_gate
+    namespace: apriltag
+    param:
+    - name: input_topic
+      value: /camera/image_raw
+    - name: output_topic
+      value: /apriltag/image_in
+    - name: start_enabled
+      value: false
+
+- node:
+    pkg: apriltag_ros
+    exec: apriltag_node
+    name: apriltag
+    namespace: apriltag
+    param:
+    - from: $(find-pkg-share openamrobot_docking)/config/tags_36h11.yaml
+    remap:
+    # Fed by the gate (was /camera/image_raw). No frames arrive until the gate
+    # is enabled -> apriltag does no work during navigation.
+    - from: /apriltag/image_rect
+      to: /apriltag/image_in
+    - from: /camera_info
+      to: /camera/camera_info
+    - from: /apriltag/camera_info
+      to: /camera/camera_info

--- a/ros2/src/openamrobot_docking/launch/docking_real.launch.py
+++ b/ros2/src/openamrobot_docking/launch/docking_real.launch.py
@@ -1,0 +1,74 @@
+"""
+Real-robot docking pipeline (no simulation).
+
+Composes the hardware-agnostic docking stack onto the REAL camera, WITHOUT any
+Gazebo glue (no GZ_SIM_RESOURCE_PATH, no ros_gz_bridge camera_info bridge, no
+camera_info_sync — the real camera already publishes a calibrated
+/camera/camera_info, started by openamrobot_bringup/real_bringup.launch.py):
+
+  - apriltag.launch.yml          — AprilTagNode on /camera/image_raw +
+                                    /camera/camera_info -> TF to the dock tags.
+  - detected_dock_pose_publisher — map -> charging_dock_tag_1 TF -> /detected_dock_pose.
+  - dock_trigger (Python)        — listens on /dock_trigger (dock) and /undock_robot,
+                                    AND owns /goal_pose: a navigation goal that arrives
+                                    while docked undocks first, then is republished on
+                                    goal_pose_forward_topic (= /goal_pose_nav). When NOT
+                                    docked the goal is forwarded immediately. This is the
+                                    real replacement for the placeholder
+                                    `topic_tools relay /goal_pose /goal_pose_nav`.
+
+  ros2 launch openamrobot_docking docking_real.launch.py
+
+Prerequisites (hardware): a physical dock with the 3-tag 36h11 bundle (IDs 0/1/2),
+the real tag size set in config/tags_36h11.yaml, the camera calibrated, and the dock
+pose set in config/dock_trigger.yaml for the real map. See the porting plan / runbook.
+"""
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import (
+    AnyLaunchDescriptionSource,
+    PythonLaunchDescriptionSource,
+)
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    pkg = get_package_share_directory('openamrobot_docking')
+    trigger_params = os.path.join(pkg, 'config', 'dock_trigger.yaml')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+            'use_sim_time', default_value='false',
+            description='Real robot uses the real clock (false).'),
+
+        # AprilTag detection on the real camera (raw image + calibrated camera_info).
+        IncludeLaunchDescription(
+            AnyLaunchDescriptionSource(
+                os.path.join(pkg, 'launch', 'apriltag.launch.yml'))),
+
+        # TF (map -> dock tag) -> /detected_dock_pose at 10 Hz.
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource(
+                os.path.join(pkg, 'launch', 'detected_dock_pose_publisher.launch.py')),
+            launch_arguments={'use_sim_time': use_sim_time}.items()),
+
+        # dock_trigger: docking sequence + the /goal_pose -> /goal_pose_nav undock gate
+        # (replaces the placeholder relay).
+        Node(
+            package='openamrobot_docking', executable='dock_trigger.py',
+            name='dock_trigger',
+            # obstacle_scan_forward_angle=π: this unit's RPLIDAR is mounted rotated 180°, so the
+            # forward obstacle cone must be offset by π (scan angle 0 points backward). Sim keeps 0.
+            # use_apriltag_gate: real robot only. The dock sequence flips the
+            # on-demand AprilTag image gate (apriltag.launch.yml) so apriltag
+            # burns CPU only during the approach, not during navigation.
+            parameters=[trigger_params, {'use_sim_time': use_sim_time,
+                                         'obstacle_scan_forward_angle': 3.14159,
+                                         'use_apriltag_gate': True}],
+            output='screen'),
+    ])

--- a/ros2/src/openamrobot_docking/package.xml
+++ b/ros2/src/openamrobot_docking/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
 
   <!-- Launch infrastructure -->

--- a/ros2/src/openamrobot_docking/scripts/apriltag_gate.py
+++ b/ros2/src/openamrobot_docking/scripts/apriltag_gate.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+On-demand image gate for AprilTag detection.
+
+AprilTag detection (``apriltag_node``) is CPU-heavy: it runs the quad detector
+on EVERY camera frame (~1.6 cores on the Pi 5). It is only needed during the
+final dock approach, NOT while the robot navigates — running it always-on
+starves the Nav2 planner/controller (the whole machine sits at load ~8 on 4
+cores, and goals take seconds to start).
+
+This gate sits between the camera and ``apriltag_node``::
+
+    /camera/image_raw ──(gate)──▶ /apriltag/image_in ──▶ apriltag_node
+
+The gate keeps ONE subscription to the camera and republishes to
+``/apriltag/image_in`` ONLY while enabled:
+
+* DISABLED (default): incoming frames are dropped here, so ``apriltag_node``
+  receives nothing and idles at ~0 % CPU. ``apriltag_node`` STAYS ALIVE
+  (already initialised, already subscribed).
+* ENABLED: frames are forwarded, so ``apriltag_node`` gets the very next one.
+
+Because ``apriltag_node`` never restarts and the camera never stops, toggling is
+just flipping a boolean — effectively instant (< 100 ms), no process start, no
+camera warm-up. That is the whole point: the docking sequence can flip detection
+on "just before it needs it" without a latency penalty.
+
+Note on the design: we deliberately keep a *permanent* subscription and gate the
+*republish*, rather than creating/destroying the subscription on each toggle.
+Creating a subscription from inside the SetBool service callback (single-threaded
+executor) is unreliable — the new subscription is discovered by DDS but its
+callback is never serviced, so no frames flow. The gate's own receive cost
+(deserialising the camera stream) is negligible at the camera frame rate and far
+below apriltag's detection cost, so this trades a tiny constant overhead for
+correctness. The heavy ~1.6-core detection is fully gated either way.
+
+Toggle with the ``std_srvs/SetBool`` service (default ``/apriltag/set_enabled``)::
+
+    ros2 service call /apriltag/set_enabled std_srvs/srv/SetBool "{data: true}"
+
+``dock_trigger`` calls it automatically: ENABLE once the robot reaches the
+staging zone (Phase 1 done), DISABLE when the sequence ends (docked / failed /
+undock). An operator UI can use the same service for a manual button.
+
+QoS: RELIABLE on both sides, matching the camera (camera_ros publishes RELIABLE
+KEEP_LAST 1) and apriltag's image_transport subscriber (RELIABLE KEEP_LAST 10).
+A best-effort reader of the reliable depth-1 camera gets STARVED once apriltag is
+also running (frames stop arriving) — measured on the Pi; a reliable reader does
+not. Do not "optimise" this back to sensor-data/best-effort.
+"""
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy, HistoryPolicy
+from sensor_msgs.msg import Image
+from std_srvs.srv import SetBool
+
+
+class AprilTagGate(Node):
+    def __init__(self):
+        super().__init__('apriltag_gate')
+        self.declare_parameter('input_topic', '/camera/image_raw')
+        self.declare_parameter('output_topic', '/apriltag/image_in')
+        # start_enabled=false so apriltag stays idle until something asks for
+        # detection. Set true for standalone apriltag testing (no dock_trigger).
+        self.declare_parameter('start_enabled', False)
+        self.declare_parameter('service_name', 'set_enabled')
+        # Throttle: forward at most this many fps to apriltag (drop the rest).
+        # apriltag processes ~10-12 fps on the Pi 5; feeding it the full camera
+        # rate overflows its input queue -> the detections it emits are 300+ ms
+        # stale (backlog). Capping the input near apriltag's capacity keeps the
+        # queue empty -> ~1-frame latency, at FULL resolution (NO precision loss,
+        # unlike lowering the camera resolution). 0 = unthrottled.
+        self.declare_parameter('max_fps', 10.0)
+
+        self.input_topic = self.get_parameter('input_topic').value
+        self.output_topic = self.get_parameter('output_topic').value
+        service_name = self.get_parameter('service_name').value
+        self.enabled = bool(self.get_parameter('start_enabled').value)
+        max_fps = float(self.get_parameter('max_fps').value)
+        self._min_interval = (1.0 / max_fps) if max_fps > 0 else 0.0
+        self._last_fwd = None
+
+        # RELIABLE everywhere to MATCH the camera (camera_ros publishes RELIABLE
+        # KEEP_LAST 1) and apriltag's image_transport subscriber (RELIABLE
+        # KEEP_LAST 10). A best-effort reader of the reliable depth-1 camera gets
+        # starved once apriltag is also running; a reliable reader does not.
+        qos = QoSProfile(reliability=ReliabilityPolicy.RELIABLE,
+                         history=HistoryPolicy.KEEP_LAST, depth=10)
+        self.pub = self.create_publisher(Image, self.output_topic, qos)
+        # ONE permanent subscription (see module docstring). No traffic is
+        # republished until self.enabled.
+        self.sub = self.create_subscription(
+            Image, self.input_topic, self._on_image, qos)
+
+        self.srv = self.create_service(SetBool, service_name, self.on_set_enabled)
+        self.get_logger().info(
+            f"AprilTag gate ready, {'ENABLED' if self.enabled else 'DISABLED'}. "
+            f"{self.input_topic} -> {self.output_topic} "
+            f"(toggle with SetBool on '{service_name}').")
+
+    def _on_image(self, msg):
+        # Forward only while enabled; otherwise drop -> apriltag gets nothing.
+        if not self.enabled:
+            return
+        # Throttle to max_fps: drop frames so apriltag is never overfed (which
+        # backs up its input queue and makes its detections stale). Full-res
+        # frames are still forwarded, just fewer of them.
+        if self._min_interval > 0.0:
+            now = self.get_clock().now()
+            if self._last_fwd is not None and \
+                    (now - self._last_fwd).nanoseconds * 1e-9 < self._min_interval:
+                return
+            self._last_fwd = now
+        self.pub.publish(msg)
+
+    def on_set_enabled(self, request, response):
+        was = self.enabled
+        self.enabled = bool(request.data)
+        if self.enabled != was:
+            self.get_logger().info(
+                'AprilTag gate ENABLED — forwarding to apriltag.' if self.enabled
+                else 'AprilTag gate DISABLED — apriltag idle (~0% CPU).')
+        response.success = True
+        response.message = 'apriltag gate ' + ('enabled' if self.enabled else 'disabled')
+        return response
+
+
+def main():
+    rclpy.init()
+    node = AprilTagGate()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -942,6 +942,9 @@ class DockTrigger(Node):
         lateral_filt = None      # EMA of the metric lateral offset (c1cam[0], m) — the
                                   # actual NEAR steering signal (depth-independent).
         last_valid_t = None     # wall-clock time filtered_angle was last actually updated
+        bnorm_at_freeze = None   # bnorm_filt snapshotted at the FAR->NEAR hand-over
+        odom_yaw_at_freeze = None  # odom yaw at that same instant — lets NEAR carry the
+                                    # dock normal forward via odometry (see _lookup_odom_yaw)
         bnorm_filt = None      # EMA of the ROBOT-frame dock normal (byaw), Phase-5 FAR
         blat_filt = None       # EMA of the lateral offset from the dock axis
         lost_frames = 0
@@ -1073,6 +1076,19 @@ class DockTrigger(Node):
                 # noisy map-frame line is dropped here on purpose.
                 if not frozen and depth <= freeze:
                     frozen = True
+                    # Snapshot the FAR-derived dock normal (robot-frame, from the wide
+                    # 2-outer-tag baseline) + the odom yaw at this exact instant. NEAR only
+                    # sees the centre tag (translation, not a trustworthy orientation), so
+                    # without this the NEAR steering law has no reference for the DOCK'S
+                    # true perpendicular — it only nulls the camera-frame lateral offset,
+                    # which converges the robot onto the line but does not constrain final
+                    # heading (a robot can keep the tag centred while arriving at an angle,
+                    # confirmed 2026-07-07: "sur la normale mais pas la bonne orientation").
+                    # Carrying bnorm_filt forward + correcting it by the odom yaw delta
+                    # (wheel+IMU EKF, LiDAR-independent) lets NEAR keep aiming at the dock's
+                    # actual normal instead of just "wherever the tag currently is".
+                    bnorm_at_freeze = bnorm_filt
+                    odom_yaw_at_freeze = self._lookup_odom_yaw()
                     # Optionally cut the LiDAR at the FAR->NEAR hand-over. DISABLED
                     # by default (stop_lidar_in_approach): on this unit stopping
                     # the motor kills the AprilTag detection within ~1 s, so the
@@ -1081,7 +1097,10 @@ class DockTrigger(Node):
                         self._set_lidar_async(False)
                     self.get_logger().info(
                         f'   depth {depth:.2f}m ≤ {freeze:.2f}m — visual corrector '
-                        f'(PD on tag-1 lateral offset, fixed lookahead)'
+                        f'(PD on tag-1 lateral offset, fixed lookahead'
+                        + (', dock-normal carried via odometry'
+                           if bnorm_at_freeze is not None and odom_yaw_at_freeze is not None
+                           else ', NO frozen normal — falling back to point-at-tag') + ')'
                         + ('; LiDAR off' if self.stop_lidar_in_approach else ''))
                 if c1cam is not None and c1cam[2] > 0.0:
                     lost_frames = 0
@@ -1093,10 +1112,21 @@ class DockTrigger(Node):
                     a = float(self.get_parameter('visual_servo_filter_alpha').value)
                     lookahead = float(self.get_parameter('visual_servo_lookahead').value)
                     now_t = time.time()
+                    # Reference heading = the dock's true normal, carried forward from the
+                    # FAR->NEAR freeze and corrected for however much the robot has turned
+                    # since (odom yaw delta, LiDAR-independent). Falls back to 0 ("just point
+                    # at the tag", the old behaviour) if FAR never established a normal or
+                    # odom is briefly unavailable — never blocks the approach on this.
+                    ref_yaw = 0.0
+                    if bnorm_at_freeze is not None and odom_yaw_at_freeze is not None:
+                        odom_yaw_now = self._lookup_odom_yaw()
+                        if odom_yaw_now is not None:
+                            ref_yaw = normalize_angle(
+                                bnorm_at_freeze - (odom_yaw_now - odom_yaw_at_freeze))
                     if filtered_angle is None:
                         filtered_angle = raw_angle
                         lateral_filt = lateral_raw
-                        desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral_filt, lookahead))
                         d_desired = 0.0
                         last_valid_t = now_t
                     elif abs(raw_angle - filtered_angle) > self.visual_servo_max_step:
@@ -1104,19 +1134,21 @@ class DockTrigger(Node):
                         # last_valid_t NOT refreshed: lateral_filt didn't move, so the
                         # next accepted frame's dt correctly spans back to the last real
                         # update, not this rejected one.
-                        desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral_filt, lookahead))
                         d_desired = 0.0
                     else:
-                        prev_desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        prev_desired_yaw = normalize_angle(
+                            ref_yaw - math.atan2(lateral_filt, lookahead))
                         filtered_angle = a * raw_angle + (1.0 - a) * filtered_angle
                         lateral_filt = a * lateral_raw + (1.0 - a) * lateral_filt
-                        # desired_yaw = -atan2(lateral, FIXED lookahead), not the raw bearing
-                        # atan2(X, Z): Z (depth) shrinks through NEAR, so the raw bearing grows
-                        # mechanically for a CONSTANT physical lateral offset — the P-term used
-                        # to intensify purely from getting closer, worst right at the end
-                        # (2026-07-07 oscillation audit). A fixed lookahead (mirrors FAR's
-                        # line_lookahead_distance pure-pursuit) removes that depth dependence.
-                        desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        # desired_yaw = ref_yaw - atan2(lateral, FIXED lookahead): aim at the
+                        # dock's actual normal (ref_yaw), pure-pursuit-corrected for the
+                        # residual lateral offset — mirrors FAR's formula exactly, just with a
+                        # frozen+odom-corrected normal instead of a continuously re-measured
+                        # one (NEAR only has the centre tag, translation only). A fixed
+                        # lookahead (not the shrinking depth) avoids the old gain blow-up
+                        # (2026-07-07 oscillation audit).
+                        desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral_filt, lookahead))
                         # Real elapsed time since the last update, NOT the nominal loop period —
                         # see the D-term dt fix above; same gap-handling logic, now applied to
                         # desired_yaw instead of the raw bearing.
@@ -1958,6 +1990,21 @@ class DockTrigger(Node):
         except Exception:
             return None
         return t.transform.translation.x, t.transform.translation.y
+
+    def _lookup_odom_yaw(self):
+        """odom->base_link yaw. Same LiDAR-independent source as _lookup_odom_xy
+        (wheel+IMU EKF) — used to carry the FAR-derived dock normal (bnorm_filt)
+        forward through NEAR by tracking how much the robot has turned since the
+        FAR->NEAR freeze, since NEAR's single centre-tag view can't re-measure
+        orientation (only translation) — see the freeze block in
+        _final_visual_approach."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'odom', 'base_link', rclpy.time.Time(),
+                timeout=Duration(seconds=0.1))
+        except Exception:
+            return None
+        return quat_to_yaw(t.transform.rotation)
 
     # ── Multi-tag perception (3 tags: id0/id2 outer, id1 centre) ──────────
     def _lookup_tag_cam(self, frame):

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -389,6 +389,15 @@ class DockTrigger(Node):
         self.dock_x = float(self.get_parameter('dock_pose_x').value)
         self.dock_y = float(self.get_parameter('dock_pose_y').value)
         self.dock_yaw = float(self.get_parameter('dock_pose_yaw').value)
+        # The shipped dock_trigger.yaml calibrates dock_pose to THIS reference room's
+        # map. On a new deployment those coordinates point Phase 1 at the wrong staging
+        # goal, so warn loudly if they were left at the reference values.
+        if abs(self.dock_x - 1.362) < 1e-3 and abs(self.dock_y - 0.222) < 1e-3:
+            self.get_logger().warn(
+                'dock_pose is at the REFERENCE-ROOM calibration (x=1.362, y=0.222). '
+                'Recalibrate dock_pose_x/y/yaw for YOUR map — measure the dock tag with '
+                '`ros2 run tf2_ros tf2_echo map charging_dock_tag_1` — or Phase 1 will '
+                'navigate to the wrong staging pose.')
         self.staging_distance = float(self.get_parameter('staging_distance').value)
         self.staging_hold_seconds = float(self.get_parameter('staging_hold_seconds').value)
         self.docking_distance = float(self.get_parameter('docking_distance').value)
@@ -817,12 +826,16 @@ class DockTrigger(Node):
         self._amcl_paused = False
         self.get_logger().info('AMCL laser correction RESUMED.')
 
-    def _set_collision_monitor(self, active: bool) -> bool:
+    def _set_collision_monitor(self, active: bool, verify: bool = False,
+                               timeout_sec: float = 3.0) -> bool:
         """Activate/deactivate Nav2's collision_monitor via its lifecycle service.
         During docking we DEACTIVATE it: it otherwise sees the dock in its stop
         zone and publishes zero on /cmd_vel, which fights dock_trigger's forward
         command (both publish /cmd_vel) → the robot judders and stalls ~15 cm from
-        the dock. Fire-and-forget (don't block the sequence on the result)."""
+        the dock. Deactivation stays fire-and-forget (its failure is fail-SAFE).
+        Re-activation is fail-DANGEROUS (the robot would navigate with no reactive
+        collision layer), so callers pass verify=True to wait on the transition,
+        bounded, and confirm it actually succeeded."""
         if not self.pause_collision_monitor_during_dock:
             return False
         try:
@@ -834,8 +847,19 @@ class DockTrigger(Node):
             req = ChangeState.Request()
             req.transition.id = (Transition.TRANSITION_ACTIVATE if active
                                  else Transition.TRANSITION_DEACTIVATE)
-            self._colmon_cli.call_async(req)
-            return True
+            future = self._colmon_cli.call_async(req)
+            if not verify:
+                return True   # deactivation: fire-and-forget (failing is fail-safe)
+            # Verified path (re-activation): wait on the result and confirm success.
+            deadline = time.monotonic() + timeout_sec
+            while not future.done():
+                if time.monotonic() > deadline:
+                    self.get_logger().warn(
+                        'collision_monitor ChangeState timed out (no response).')
+                    return False
+                time.sleep(0.02)
+            resp = future.result()
+            return bool(resp is not None and resp.success)
         except Exception as e:
             self.get_logger().warn(f'collision_monitor state change failed: {e}')
             return False
@@ -850,12 +874,29 @@ class DockTrigger(Node):
                 'approach ~15 cm out).')
 
     def _resume_collision_monitor(self):
-        """Re-activate the collision_monitor after the dock (idempotent)."""
+        """Re-activate the collision_monitor after the dock. Unlike the pause, this is
+        safety-critical: a dropped or rejected resume would return the robot to normal
+        navigation with NO reactive collision layer while the log claims otherwise. So
+        we verify the transition, retry a few times, and if it still will not come back
+        we log at ERROR and publish a distinct status instead of claiming success."""
         if not self._colmon_paused:
             return
-        self._set_collision_monitor(True)
-        self._colmon_paused = False
-        self.get_logger().info('collision_monitor RE-ACTIVATED.')
+        for attempt in range(1, 4):
+            if self._set_collision_monitor(True, verify=True):
+                self._colmon_paused = False
+                self.get_logger().info('collision_monitor RE-ACTIVATED (confirmed).')
+                return
+            self.get_logger().warn(
+                f'collision_monitor re-activation not confirmed '
+                f'(attempt {attempt}/3), retrying…')
+            time.sleep(0.3)
+        # Still down after retries — fail-dangerous. Keep _colmon_paused=True (do not
+        # pretend it is back), shout at ERROR, and flag the operator via a distinct status.
+        self.get_logger().error(
+            'collision_monitor RE-ACTIVATION FAILED after 3 attempts — the robot is '
+            'navigating WITHOUT its reactive collision layer. Restore it manually: '
+            'ros2 lifecycle set /collision_monitor activate')
+        self._pub_status('collision_monitor_down')
 
     def _marker_tick(self):
         """While docking (but OUTSIDE the NEAR loop, which draws its own marker),

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -344,7 +344,7 @@ class DockTrigger(Node):
         # check — the dock itself is "an obstacle" we are approaching on
         # purpose. The centring scan / spin-in-place phases also skip it
         # (the robot is rotating in place, not translating into anything).
-        self.declare_parameter('obstacle_check_enabled', True)
+        self.declare_parameter('obstacle_check_enabled', False)  # off by default — the dock trips it
         self.declare_parameter('obstacle_scan_topic', '/scan_filtered')
         self.declare_parameter('obstacle_forward_distance', 0.6)        # m — stop if obstacle within this distance ahead
         # No obstacle_backward_distance: scan_body_filter chops the rear ±40°

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -47,9 +47,12 @@ from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.duration import Duration
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+from rclpy.parameter import Parameter
+from rclpy.parameter_client import AsyncParameterClient
 
-from std_msgs.msg import Bool, String
+from std_msgs.msg import Bool, String, Float32
 from std_srvs.srv import SetBool, Empty
+from rcl_interfaces.msg import SetParametersResult
 from geometry_msgs.msg import Point, PoseStamped, Twist
 from sensor_msgs.msg import LaserScan
 from nav2_msgs.action import (
@@ -126,8 +129,19 @@ class DockTrigger(Node):
         self.declare_parameter('staging_hold_seconds', 1.0)    # robot stationary
 
         # Docking
-        self.declare_parameter('docking_distance', 0.6)        # final distance from tag (m)
+        self.declare_parameter('docking_distance', 0.6)        # final CAMERA→tag depth (m) — fallback stop
+        # Preferred stop: the FORWARD LiDAR distance to the dock (physical, robust — the camera→tag
+        # depth can drift close up). Stop when the min range in a narrow forward cone ≤ stop_lidar_distance.
+        # Camera depth is the fallback when the LiDAR has no valid forward return.
+        self.declare_parameter('stop_on_lidar', True)
+        self.declare_parameter('stop_lidar_distance', 0.25)    # m — LiDAR→dock at the final stop
+        self.declare_parameter('stop_lidar_arc_half_deg', 12.0) # deg — half-width of the forward stop cone (live-tunable)
         self.declare_parameter('drive_speed', 0.10)            # m/s forward
+        # Floor of the near-dock taper = the speed of the LAST centimetres. Raise
+        # it (e.g. 0.12) to keep MOMENTUM through the dock's little step/lip so the
+        # robot climbs it even on a LOW battery (docking happens at low charge by
+        # definition). 0.05 = the gentle clean-stop floor (no step). Live-tunable.
+        self.declare_parameter('final_push_speed', 0.05)       # m/s
         self.declare_parameter('drive_yaw_kp', 1.5)            # angular P gain during drive
         self.declare_parameter('drive_yaw_max_omega', 0.5)     # rad/s clamp on correction
         # Rotation stiction floor. Measured on this robot
@@ -231,7 +245,13 @@ class DockTrigger(Node):
 
         # Tag detection
         self.declare_parameter('detection_topic', '/detected_dock_pose')
-        self.declare_parameter('detection_max_age', 1.5)       # s — drop stale msgs
+        self.declare_parameter('detection_max_age', 1.5)       # s — drop stale tag TFs (live)
+        # Clean approach (2026-07-09): keep the dock line in the ODOM frame at all
+        # times, refined by tags looked up directly in odom (lag-correct), same
+        # pure-pursuit law whether 3 tags / 1 tag / none are fresh — no base_link↔
+        # odom tier switch, so the reference never swings with the robot and there
+        # is no tier-boundary jump. False = legacy tier cascade. Live-tunable.
+        self.declare_parameter('unified_odom_line', True)
 
         # ── On-demand AprilTag image gate (real robot) ─────────────────────
         # apriltag_node is CPU-heavy (~1.6 cores on the Pi) and only needed for
@@ -273,6 +293,15 @@ class DockTrigger(Node):
         self.declare_parameter('predock_distance', 1.5)          # m on the normal (P1)
         self.declare_parameter('refined_predock_distance', 1.30) # m on the normal (P2)
         self.declare_parameter('normal_tolerance_deg', 5.0)      # deg — N vs N' agreement
+        self.declare_parameter('normal_agreement_tol_deg', 8.0)  # deg — geom vs orientation normal must agree (3-tag gate)
+        # Pause AMCL's laser correction during the dock maneuver: high update_min_d/a make AMCL stop
+        # folding in scans, so map->odom is propagated on ODOMETRY only (smooth, no relocalisation
+        # jumps when nearby objects have moved). Restored on dock end/abort. See docs/13_perception.
+        self.declare_parameter('pause_amcl_during_dock', True)
+        self.declare_parameter('amcl_pause_min_d', 1000.0)       # m  — huge = AMCL never laser-updates
+        self.declare_parameter('amcl_pause_min_a', 1000.0)       # rad
+        self.declare_parameter('amcl_resume_min_d', 0.25)        # m  — AMCL default, restored after
+        self.declare_parameter('amcl_resume_min_a', 0.2)         # rad
         self.declare_parameter('obs_lateral', 0.5)               # m — side offset for obs B
         self.declare_parameter('obs_distance', 2.0)              # m from tag for obs B
         # Only gates the LEGACY map-frame leg of _final_visual_approach
@@ -355,6 +384,14 @@ class DockTrigger(Node):
         self.staging_distance = float(self.get_parameter('staging_distance').value)
         self.staging_hold_seconds = float(self.get_parameter('staging_hold_seconds').value)
         self.docking_distance = float(self.get_parameter('docking_distance').value)
+        self.stop_on_lidar = bool(self.get_parameter('stop_on_lidar').value)
+        self.stop_lidar_distance = float(self.get_parameter('stop_lidar_distance').value)
+        self.stop_lidar_arc_half = math.radians(
+            float(self.get_parameter('stop_lidar_arc_half_deg').value))
+        # Live-tunable stop distances: `ros2 param set /dock_trigger stop_lidar_distance X`
+        # (or docking_distance / stop_on_lidar) takes effect on the NEXT dock, no relaunch
+        # (handy while tuning the final gap). See _on_set_params.
+        self.add_on_set_parameters_callback(self._on_set_params)
         self.drive_speed = float(self.get_parameter('drive_speed').value)
         self.drive_yaw_kp = float(self.get_parameter('drive_yaw_kp').value)
         self.drive_yaw_max_omega = float(self.get_parameter('drive_yaw_max_omega').value)
@@ -379,6 +416,7 @@ class DockTrigger(Node):
         self.spin_min_omega = float(self.get_parameter('spin_min_omega').value)
         self.detection_topic = self.get_parameter('detection_topic').value
         self.detection_max_age = float(self.get_parameter('detection_max_age').value)
+        self.unified_odom_line = bool(self.get_parameter('unified_odom_line').value)
         self.use_apriltag_gate = bool(self.get_parameter('use_apriltag_gate').value)
         self.apriltag_gate_service = self.get_parameter('apriltag_gate_service').value
         self.filter_num_samples = int(self.get_parameter('filter_num_samples').value)
@@ -395,6 +433,15 @@ class DockTrigger(Node):
         self.refined_predock_distance = float(self.get_parameter('refined_predock_distance').value)
         self.normal_tolerance = math.radians(
             float(self.get_parameter('normal_tolerance_deg').value))
+        self.normal_agreement_tol = math.radians(
+            float(self.get_parameter('normal_agreement_tol_deg').value))
+        self.pause_amcl_during_dock = bool(self.get_parameter('pause_amcl_during_dock').value)
+        self.amcl_pause_min_d = float(self.get_parameter('amcl_pause_min_d').value)
+        self.amcl_pause_min_a = float(self.get_parameter('amcl_pause_min_a').value)
+        self.amcl_resume_min_d = float(self.get_parameter('amcl_resume_min_d').value)
+        self.amcl_resume_min_a = float(self.get_parameter('amcl_resume_min_a').value)
+        self._amcl_paused = False
+        self._amcl_param_cli = AsyncParameterClient(self, 'amcl')
         self.obs_lateral = float(self.get_parameter('obs_lateral').value)
         self.obs_distance = float(self.get_parameter('obs_distance').value)
         self.freeze_axis_distance = float(self.get_parameter('freeze_axis_distance').value)
@@ -447,7 +494,18 @@ class DockTrigger(Node):
 
         # ── Laser scan subscription (obstacle avoidance) ────────────────────
         self.latest_scan = None
-        if self.obstacle_check_enabled:
+        # Republish ONLY the forward stop-cone on its own topic, so it can be shown as
+        # a dedicated LaserScan display in RViz (exactly what the lidar-stop looks at).
+        self._scan_fwd_pub = self.create_publisher(LaserScan, '/scan_forward', 10)
+        # Robot's signed perpendicular error from the reference line (m) — echo/plot
+        # /docking/lateral_error to SEE how far off the line the robot is, live.
+        self._lateral_pub = self.create_publisher(Float32, '/docking/lateral_error', 10)
+        # The scan now feeds THREE things: the obstacle check, the lidar-STOP, and the
+        # /scan_forward debug topic. Subscribe whenever ANY of them needs it — the old
+        # gate was obstacle_check_enabled ALONE, which (being off) starved the lidar-stop
+        # of data (latest_scan stayed None → _min_range_in_arc always inf → the robot
+        # drove into the dock). This one line is the fix.
+        if self.obstacle_check_enabled or self.stop_on_lidar:
             self.create_subscription(
                 LaserScan, self.obstacle_scan_topic, self.on_scan, 10,
                 callback_group=self.cb_group,
@@ -476,6 +534,13 @@ class DockTrigger(Node):
         # ── Debug marker publisher (perpendicular line + tag centre) ────────
         self.marker_pub = self.create_publisher(
             MarkerArray, self.debug_marker_topic, 10)
+        # Show the dock normal from the moment the tags are visible (Phase 2/3), not
+        # only during the NEAR loop. A timer publishes the marker while docking is
+        # active but OUTSIDE the NEAR loop (which publishes its own, richer marker).
+        self._docking_active = False
+        self._in_near_loop = False
+        self._odom_line = None
+        self._marker_timer = self.create_timer(0.15, self._marker_tick)
 
         # ── Docking status publisher (consumed by the web UI, from upstream) ─
         # Publishes one of: idle | docking | docked | undocking | failed
@@ -617,6 +682,30 @@ class DockTrigger(Node):
 
     def on_scan(self, msg: LaserScan):
         self.latest_scan = msg
+        self._publish_forward_scan(msg)
+
+    def _publish_forward_scan(self, msg: LaserScan):
+        """Republish ONLY the forward stop-cone of the scan on /scan_forward (rays
+        outside ±stop_lidar_arc_half around obstacle_scan_forward_angle → inf), so it
+        shows as its own LaserScan display = exactly what the lidar-stop reads."""
+        out = LaserScan()
+        out.header = msg.header
+        out.angle_min = msg.angle_min
+        out.angle_max = msg.angle_max
+        out.angle_increment = msg.angle_increment
+        out.time_increment = msg.time_increment
+        out.scan_time = msg.scan_time
+        out.range_min = msg.range_min
+        out.range_max = msg.range_max
+        center, half = self.obstacle_scan_forward_angle, self.stop_lidar_arc_half
+        ranges = list(msg.ranges)
+        for i in range(len(ranges)):
+            a = msg.angle_min + i * msg.angle_increment
+            if abs(normalize_angle(a - center)) > half:
+                ranges[i] = float('inf')
+        out.ranges = ranges
+        out.intensities = []
+        self._scan_fwd_pub.publish(out)
 
     def on_trigger(self, msg: Bool):
         if msg.data:
@@ -629,13 +718,116 @@ class DockTrigger(Node):
         elif self.undock_on_false:
             self._send_undock()
 
+    def _on_set_params(self, params):
+        """Apply live parameter changes (used on the NEXT loop/dock, no relaunch):
+        docking_distance, stop_lidar_distance, stop_on_lidar, detection_max_age — so
+        the final stop / tag-loss handoff can be tuned with `ros2 param set
+        /dock_trigger …` while iterating."""
+        for p in params:
+            try:
+                if p.name == 'docking_distance':
+                    self.docking_distance = float(p.value)
+                    self.get_logger().info(
+                        f'docking_distance -> {self.docking_distance:.2f} m (live)')
+                elif p.name == 'stop_lidar_distance':
+                    self.stop_lidar_distance = float(p.value)
+                    self.get_logger().info(
+                        f'stop_lidar_distance -> {self.stop_lidar_distance:.2f} m (live)')
+                elif p.name == 'stop_on_lidar':
+                    self.stop_on_lidar = bool(p.value)
+                    self.get_logger().info(f'stop_on_lidar -> {self.stop_on_lidar} (live)')
+                elif p.name == 'stop_lidar_arc_half_deg':
+                    self.stop_lidar_arc_half = math.radians(float(p.value))
+                    self.get_logger().info(
+                        f'stop_lidar_arc_half -> ±{float(p.value):.0f}° (live)')
+                elif p.name == 'detection_max_age':
+                    # How long a tag TF stays 'valid' after the camera last saw it.
+                    # SMALL = drop a lost tag fast so the NEAR loop falls to the
+                    # odom-frozen line (tier 3) instead of coasting on the stale,
+                    # base_link-locked detection (which slides WITH the robot and
+                    # never re-corrects). Must stay above the inter-detection gap
+                    # (~0.25 s at 4 Hz) or a single dropped frame flips to odom.
+                    self.detection_max_age = float(p.value)
+                    self.get_logger().info(
+                        f'detection_max_age -> {self.detection_max_age:.2f} s (live)')
+                elif p.name == 'unified_odom_line':
+                    self.unified_odom_line = bool(p.value)
+                    self.get_logger().info(
+                        f'unified_odom_line -> {self.unified_odom_line} (live)')
+            except (TypeError, ValueError):
+                return SetParametersResult(
+                    successful=False, reason=f'bad value for {p.name}')
+        return SetParametersResult(successful=True)
+
+    def _set_amcl_updates(self, min_d, min_a) -> bool:
+        """Set AMCL's update_min_d/update_min_a (target node 'amcl') via its parameter
+        service. Huge values PAUSE the laser correction: AMCL stops folding scans into
+        the filter and just propagates map->odom on odometry (smooth, no relocalisation
+        jumps). Returns True if the set was dispatched."""
+        if not self.pause_amcl_during_dock:
+            return False
+        try:
+            if not self._amcl_param_cli.wait_for_services(timeout_sec=2.0):
+                self.get_logger().warn(
+                    'AMCL param service unavailable — skipping AMCL pause/resume '
+                    '(map->odom jumps may perturb the dock if AMCL relocalises).')
+                return False
+            self._amcl_param_cli.set_parameters([
+                Parameter('update_min_d', Parameter.Type.DOUBLE, float(min_d)),
+                Parameter('update_min_a', Parameter.Type.DOUBLE, float(min_a)),
+            ])
+            return True
+        except Exception as e:
+            self.get_logger().warn(f'AMCL param set failed: {e}')
+            return False
+
+    def _pause_amcl(self):
+        """Freeze AMCL's laser correction for the dock maneuver — map->odom then rides
+        on odometry only (smooth), so the tag-referenced targets stop jumping."""
+        if self._set_amcl_updates(self.amcl_pause_min_d, self.amcl_pause_min_a):
+            self._amcl_paused = True
+            self.get_logger().info(
+                f'AMCL laser correction PAUSED (update_min_d={self.amcl_pause_min_d:.0f}) '
+                '— map->odom frozen on odometry for the dock.')
+
+    def _resume_amcl(self):
+        """Restore AMCL's normal laser correction (idempotent)."""
+        if not self._amcl_paused:
+            return
+        self._set_amcl_updates(self.amcl_resume_min_d, self.amcl_resume_min_a)
+        self._amcl_paused = False
+        self.get_logger().info('AMCL laser correction RESUMED.')
+
+    def _marker_tick(self):
+        """While docking (but OUTSIDE the NEAR loop, which draws its own marker),
+        publish the live dock normal as soon as the 3 tags are visible — so the
+        line appears from Phase 2/3 onward, not only at the final approach. In these
+        early phases there is no filtered reference yet, so green ≈ blue (both the
+        current estimate)."""
+        # Draw whenever the NEAR loop isn't (it draws its own richer marker). NOT gated
+        # on _docking_active anymore, so the normal shows as soon as the robot sees the
+        # 3 tags — even at rest — handy to check line-following before/without a dock.
+        if self._in_near_loop:
+            return
+        self._publish_forward_lidar_points()   # RED: forward lidar points
+        est = self._estimate_dock_base_once()
+        if est is not None:
+            # Phase 2/3: one normal only (no filtered-reference vs raw-current split
+            # yet) → publish it GREEN (the reference line, from its creation). The
+            # blue raw-current line appears in the NEAR loop, where the two diverge.
+            self._publish_docking_line_marker(est[0], est[1], est[2])
+
     def _run_and_release(self):
         self._pub_status('docking')
+        self._docking_active = True   # timer draws the normal from Phase 2/3 on
+        self._pause_amcl()          # freeze map->odom: no relocalisation jumps during the maneuver
         try:
             self.run_docking_sequence()
         except Exception as e:
             self.get_logger().error(f'Docking sequence error: {e}')
         finally:
+            self._docking_active = False   # stop the Phase 2/3 marker timer
+            self._resume_amcl()     # AMCL laser correction back on (success, abort, or exception)
             self._set_apriltag(False)   # apriltag back to ~0% CPU
             if self.stop_lidar_in_approach:
                 self._set_lidar(True)   # LiDAR back on (only if we stopped it)
@@ -784,7 +976,12 @@ class DockTrigger(Node):
         # _run_and_release finally.
         self.get_logger().info(
             f'── Phase 5: visual approach to {self.docking_distance:.2f}m (camera depth)')
-        if not self._final_visual_approach(cx, cy, normal_yaw):
+        self._in_near_loop = True    # NEAR loop draws its own marker; pause the timer
+        try:
+            near_ok = self._final_visual_approach(cx, cy, normal_yaw)
+        finally:
+            self._in_near_loop = False
+        if not near_ok:
             self.get_logger().error('   final approach failed')
             return
 
@@ -795,68 +992,112 @@ class DockTrigger(Node):
     # Camera-centric helpers (see docs/13_perception_and_line.md §6)
     # ──────────────────────────────────────────────────────────────────────
     def _estimate_dock(self, num_samples=None):
-        """Average num_samples joint observations of the three tags' map
-        positions, then derive the dock target and normal:
+        """Average num_samples joint observations of the three tags' map poses
+        (position AND facing), then derive the dock target + normal via
+        _dock_pose_from_tags (geometry + orientation, agreement-gated).
 
-          - dock target = the CENTRE tag (id1), the point we drive onto;
-          - dock normal = perpendicular to the wide baseline between the OUTER
-            tags (id0→id2), disambiguated toward the robot.
-
-        Using the outer tag *centres* and their wide baseline gives a far more
-        robust dock orientation than a single-tag solvePnP normal.
-
-        Returns (cx, cy, normal_yaw) or None.
+        Requires ALL THREE tags together — no partial-view fallback. Returns
+        (cx, cy, normal_yaw) or None.
         """
         if num_samples is None:
             num_samples = self.filter_num_samples
-        s = [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]]   # sums for tag 0,1,2
+        # per-tag running sums: [x, y, sin(yaw), cos(yaw)] (circular mean of yaw)
+        s = [[0.0, 0.0, 0.0, 0.0] for _ in range(3)]
         n = 0
         last_key = None
         deadline = time.time() + self.filter_max_collect_time
         while time.time() < deadline and n < num_samples:
-            p0 = self._lookup_tag_map('charging_dock_tag_0')
-            p1 = self._lookup_tag_map('charging_dock_tag_1')
-            p2 = self._lookup_tag_map('charging_dock_tag_2')
+            p0 = self._lookup_tag_map3('charging_dock_tag_0')
+            p1 = self._lookup_tag_map3('charging_dock_tag_1')
+            p2 = self._lookup_tag_map3('charging_dock_tag_2')
             if p0 is not None and p1 is not None and p2 is not None:
                 key = (round(p0[0], 4), round(p1[0], 4), round(p2[0], 4))
                 if key != last_key:        # don't count an unchanged TF twice
                     for i, p in enumerate((p0, p1, p2)):
                         s[i][0] += p[0]
                         s[i][1] += p[1]
+                        s[i][2] += math.sin(p[2])
+                        s[i][3] += math.cos(p[2])
                     n += 1
                     last_key = key
             time.sleep(0.05)
         if n == 0:
             self.get_logger().error('   never saw all three tags together')
             return None
-        c0 = (s[0][0] / n, s[0][1] / n)
-        c1 = (s[1][0] / n, s[1][1] / n)
-        c2 = (s[2][0] / n, s[2][1] / n)
+        c = [(s[i][0] / n, s[i][1] / n, math.atan2(s[i][2], s[i][3]))
+             for i in range(3)]
         pose = self.lookup_robot_pose()
         if pose is None:
             return None
         rx, ry, _ = pose
-        return self._dock_pose_from_tags(c0, c1, c2, rx, ry)
+        return self._dock_pose_from_tags(c[0], c[1], c[2], rx, ry)
 
     def _dock_pose_from_tags(self, c0, c1, c2, rx, ry):
-        """Dock target + heading-to-dock from the three tag centres.
+        """Dock target + heading-to-dock from the THREE tags (position + orientation).
 
-        Target = midpoint of the OUTER tags (c0+c2)/2. The outer tags are big
-        and well localised, so their midpoint pins the dock centre more
-        precisely than the small centre tag (and equals it geometrically). The
-        normal is perpendicular to the wide baseline c0→c2, disambiguated toward
-        the robot; the returned yaw faces the robot toward the dock.
+        Each ci = (x, y, yaw_tag), where yaw_tag is the tag's own facing direction
+        (its +Z axis projected to the ground). Two INDEPENDENT normal estimates
+        are computed and cross-checked:
+
+          1. GEOMETRIC — total-least-squares line fit through the three tag
+             centres (the dock face is a horizontal tag row); the dock normal is
+             that fitted line's perpendicular. Using all three centres (not just
+             the outer pair) rejects a single mis-localised tag.
+          2. ORIENTATION — circular mean of the three tags' facing yaws.
+
+        If the two disagree by more than `normal_agreement_tol`, the frame is a
+        bad measurement → return None (this is what keeps the normal *exact*).
+        Otherwise the two are fused (circular mean).
+
+        The dock target/anchor is the CENTRE tag c1 — the normal passes through
+        tag 1, the point we drive onto. The returned yaw faces the robot TOWARD
+        the dock. Returns (cx, cy, normal_yaw) or None.
         """
-        cx = 0.5 * (c0[0] + c2[0])          # midpoint of the precise outer tags
-        cy = 0.5 * (c0[1] + c2[1])
-        dx, dy = c2[0] - c0[0], c2[1] - c0[1]   # wide baseline
-        L = math.hypot(dx, dy)
-        if L < 1e-6:
+        pts = (c0, c1, c2)
+        # anchor = the centre tag (tag 1) — the normal passes through it.
+        cx, cy = c1[0], c1[1]
+
+        # (1) GEOMETRIC normal: total-least-squares line through the 3 centres.
+        mx = (c0[0] + c1[0] + c2[0]) / 3.0
+        my = (c0[1] + c1[1] + c2[1]) / 3.0
+        sxx = sxy = syy = 0.0
+        for p in pts:
+            ex, ey = p[0] - mx, p[1] - my
+            sxx += ex * ex
+            sxy += ex * ey
+            syy += ey * ey
+        if (sxx + syy) < 1e-9:               # tags coincident → degenerate
             return None
-        nx, ny = -dy / L, dx / L            # perpendicular to the tag row
-        if nx * (rx - cx) + ny * (ry - cy) < 0.0:
-            nx, ny = -nx, -ny               # point toward the robot
-        return cx, cy, math.atan2(-ny, -nx)
+        theta = 0.5 * math.atan2(2.0 * sxy, sxx - syy)   # principal (line) axis
+        gnx, gny = -math.sin(theta), math.cos(theta)     # perpendicular = normal
+        if gnx * (rx - cx) + gny * (ry - cy) < 0.0:
+            gnx, gny = -gnx, -gny            # point toward the robot
+        n_geom = math.atan2(gny, gnx)
+
+        # (2) ORIENTATION normal: circular mean of the tags' facing yaws.
+        sc = sum(math.sin(p[2]) for p in pts)
+        cc = sum(math.cos(p[2]) for p in pts)
+        if abs(sc) < 1e-9 and abs(cc) < 1e-9:
+            return None
+        n_orient = math.atan2(sc, cc)
+        onx, ony = math.cos(n_orient), math.sin(n_orient)
+        if onx * (rx - cx) + ony * (ry - cy) < 0.0:      # same convention: toward robot
+            n_orient = normalize_angle(n_orient + math.pi)
+
+        # (3) AGREEMENT GATE — reject a noisy frame outright.
+        disagree = abs(normalize_angle(n_geom - n_orient))
+        if disagree > self.normal_agreement_tol:
+            self.get_logger().warn(
+                f'   normal rejected: geom {math.degrees(n_geom):.1f}° vs orient '
+                f'{math.degrees(n_orient):.1f}° disagree {math.degrees(disagree):.1f}° '
+                f'> {math.degrees(self.normal_agreement_tol):.1f}°')
+            return None
+
+        # (4) FUSE the two agreeing normals (circular mean, both point toward robot).
+        fx = math.cos(n_geom) + math.cos(n_orient)
+        fy = math.sin(n_geom) + math.sin(n_orient)
+        toward_robot = math.atan2(fy, fx)
+        return cx, cy, normalize_angle(toward_robot + math.pi)   # face toward dock
 
     def _goto_point_on_normal(self, tag_x, tag_y, normal_yaw, dist):
         """Drive to the point `dist` metres in front of the tag along its
@@ -928,6 +1169,10 @@ class DockTrigger(Node):
         lost_frames = 0          # consecutive fully-blind (tier 3) frames
         last_cam_depth = None       # last camera depth to tag 1 (odom dead-reckoning)
         last_odom = None            # odom xy captured with last_cam_depth
+        last_lidar_dist = None      # last valid forward LiDAR range (odom dead-reckoning)
+        last_lidar_odom = None      # odom xy captured with last_lidar_dist
+        self._odom_line = None      # dock line frozen in the ODOM frame (tier-3 steering)
+        lateral = 0.0               # robot's signed perpendicular error from the line (m)
 
         pose0 = self.lookup_robot_pose()
         if pose0 is None:
@@ -963,10 +1208,38 @@ class DockTrigger(Node):
                 depth = last_depth
             last_depth = depth
 
-            if depth <= self.docking_distance:
+            # Forward LiDAR distance (with odom dead-reckon when it loses the dock).
+            # NOTE: _min_range_in_arc returns the CLOSEST return in the cone — a thin
+            # dock the lidar can't see cleanly lets a FARTHER wall dominate the min, so
+            # the lidar alone can fail to ever reach the threshold. Hence the failsafe.
+            lidar_dist, lidar_src = None, 'lidar'
+            if self.stop_on_lidar:
+                lidar_raw = self._min_range_in_arc(self.obstacle_scan_forward_angle,
+                                                   self.stop_lidar_arc_half)
+                if math.isfinite(lidar_raw):
+                    lidar_dist = lidar_raw
+                    if odom is not None:
+                        last_lidar_dist, last_lidar_odom = lidar_raw, odom
+                elif (last_lidar_dist is not None and last_lidar_odom is not None
+                      and odom is not None):
+                    lidar_dist = max(0.0, last_lidar_dist - math.hypot(
+                        odom[0] - last_lidar_odom[0], odom[1] - last_lidar_odom[1]))
+                    lidar_src = 'lidar-dr'
+
+            # STOP on whichever sensor says 'close' FIRST (failsafe). The camera depth
+            # (odom-dead-reckoned above) is the proven trigger — it stopped fine before
+            # the lidar was added — so the robot never charges into the dock even when
+            # the lidar misses it. The lidar is an additional earlier trigger when it
+            # DOES see the dock. Both readings are logged to tune/debug the lidar.
+            cam_close = depth <= self.docking_distance
+            lidar_close = lidar_dist is not None and lidar_dist <= self.stop_lidar_distance
+            if cam_close or lidar_close:
                 self._publish_cmd_vel(0.0, 0.0)
+                src = lidar_src if lidar_close else 'camera'
                 self.get_logger().info(
-                    f'   docked: depth {depth:.3f}m ≤ {self.docking_distance:.2f}m')
+                    f'   docked ({src}) — cam depth {depth:.3f}m (≤{self.docking_distance:.2f}), '
+                    f'lidar {("%.3f" % lidar_dist) if lidar_dist is not None else "n/a"}m '
+                    f'(≤{self.stop_lidar_distance:.2f})')
                 return True
 
             # Travel-safety bound only when a pose is available.
@@ -984,7 +1257,75 @@ class DockTrigger(Node):
             drive_speed = float(self.get_parameter('drive_speed').value)
             est_base = self._estimate_dock_base_once() if use_cam else None
 
-            if est_base is not None:
+            if self.unified_odom_line:
+                # ===== UNIFIED ODOM-LINE (clean, 2026-07-09) =================
+                # ONE reference frame: the dock line lives in odom. Fresh tags
+                # (looked up DIRECTLY in odom, lag-correct) EMA-refine it; only
+                # the centre tag → re-anchor POSITION (hold normal); no tag →
+                # the line stays put and the robot coasts onto it via odometry.
+                # No base_link↔odom switch → the reference never swings with the
+                # robot and there is no tier-boundary jump. Same pure-pursuit law.
+                op = self._lookup_odom_pose()
+                est_odom = self._estimate_dock_odom_once()
+                c1_odom = self._lookup_tag_odom3('charging_dock_tag_1')
+                refined = False
+                if op is not None and est_odom is not None:
+                    ecx, ecy, enorm = est_odom
+                    if self._odom_line is None:
+                        self._odom_line = (ecx, ecy, enorm)          # first lock
+                    elif depth > freeze:
+                        ax, ay, norm = self._odom_line
+                        spike = float(self.get_parameter('axis_spike_reject').value)
+                        a_n = max(0.05, min(0.20, self.axis_filter_alpha
+                                  * (depth / self.predock_distance)))
+                        dev = abs(normalize_angle(enorm - norm))
+                        if dev <= spike:
+                            stability = max(0.15, 1.0 - dev / spike)
+                            ae = a_n * stability
+                            norm = normalize_angle(
+                                norm + ae * normalize_angle(enorm - norm))
+                            ax = (1.0 - ae) * ax + ae * ecx
+                            ay = (1.0 - ae) * ay + ae * ecy
+                        else:
+                            # normal spike rejected — hold it, nudge position only
+                            ax = 0.9 * ax + 0.1 * ecx
+                            ay = 0.9 * ay + 0.1 * ecy
+                        self._odom_line = (ax, ay, norm)
+                    else:
+                        # depth <= freeze: hold the normal, re-anchor POSITION from
+                        # the fresh centre tag to shed accumulated odom drift.
+                        ax, ay, norm = self._odom_line
+                        self._odom_line = (0.9 * ax + 0.1 * ecx,
+                                           0.9 * ay + 0.1 * ecy, norm)
+                    refined = True
+                elif (op is not None and c1_odom is not None
+                        and self._odom_line is not None):
+                    # Only the centre tag: re-anchor position, hold the normal.
+                    ax, ay, norm = self._odom_line
+                    self._odom_line = (0.9 * ax + 0.1 * c1_odom[0],
+                                       0.9 * ay + 0.1 * c1_odom[1], norm)
+                    refined = True
+
+                if op is not None and self._odom_line is not None:
+                    rx_u, ry_u, ryaw_u = op
+                    ax, ay, norm = self._odom_line
+                    dx, dy = ax - rx_u, ay - ry_u
+                    lateral = dx * math.sin(norm) - dy * math.cos(norm)
+                    desired_yaw_odom = normalize_angle(
+                        norm - math.atan2(lateral, lookahead))
+                    omega = line_kp * normalize_angle(desired_yaw_odom - ryaw_u)
+                    bnorm_filt = normalize_angle(norm - ryaw_u)   # for log/marker
+                    cc_u, ss_u = math.cos(ryaw_u), math.sin(ryaw_u)
+                    self._publish_docking_line_marker(
+                        dx * cc_u + dy * ss_u, -dx * ss_u + dy * cc_u, bnorm_filt,
+                        current_yaw=(normalize_angle(est_odom[2] - ryaw_u)
+                                     if est_odom is not None else None))
+                    lost_frames = 0 if refined else lost_frames + 1
+                else:
+                    omega = 0.0
+                    lateral = 0.0
+                    lost_frames += 1
+            elif est_base is not None:
                 # Tier 1 — ROBOT-FRAME dock-normal pure-pursuit (2+ tags). The axis
                 # is re-derived in base_link (robot at the origin facing +x) every
                 # loop, so it NEVER reads the wobbly map (AMCL relocalisation
@@ -1065,7 +1406,8 @@ class DockTrigger(Node):
                 omega = line_kp * desired_yaw
                 lost_frames = 0
                 lateral_t2_filt = None   # reset tier 2's smoother — see tier 2 below
-                self._publish_docking_line_marker(bcx, bcy, bnorm_filt)
+                self._publish_docking_line_marker(bcx, bcy, bnorm_filt, current_yaw=byaw)
+                self._snapshot_odom_line(bcx, bcy, bnorm_filt)   # freeze on the dock (odom)
             elif (not use_cam) and pose is not None and depth > freeze:
                 rx, ry, ryaw = pose
                 # LEGACY map-frame leg (use_camera_frame_normal:=false): the
@@ -1137,13 +1479,33 @@ class DockTrigger(Node):
                 p1_base = self._lookup_tag_base('charging_dock_tag_1')
                 if p1_base is not None:
                     self._publish_docking_line_marker(p1_base[0], p1_base[1], ref_yaw)
+                    self._snapshot_odom_line(p1_base[0], p1_base[1], ref_yaw)  # keep odom line fresh
             else:
-                # Tier 3 — nothing visible at all: go BLIND. No steering attempt,
-                # just keep advancing straight; depth is dead-reckoned from
-                # odometry above, so 'docked' still triggers correctly.
+                # Tier 3 — no tags at all. Instead of going blind-straight, steer on
+                # the ODOM-frozen dock line (captured in tier 1/2): it stays fixed on
+                # the dock in the world, so we dead-reckon the robot's LATERAL offset
+                # from it via odometry and keep correcting — the last blind centimetres
+                # arrive STRAIGHT, and the marker stays on the dock instead of sliding
+                # with the robot. Same pure-pursuit law/gain as tier 1 (consistent).
                 lost_frames += 1
-                omega = 0.0
-                lateral_t2_filt = None   # reset tier 2's smoother — see tier 2 above
+                lateral_t2_filt = None
+                op = self._lookup_odom_pose()
+                if self._odom_line is not None and op is not None:
+                    rx_o, ry_o, ryaw_o = op
+                    ax_o, ay_o, norm_o = self._odom_line
+                    dxl, dyl = ax_o - rx_o, ay_o - ry_o
+                    lateral = dxl * math.sin(norm_o) - dyl * math.cos(norm_o)
+                    desired_yaw_odom = normalize_angle(
+                        norm_o - math.atan2(lateral, lookahead))
+                    omega = line_kp * normalize_angle(desired_yaw_odom - ryaw_o)
+                    # Marker: project the odom line back into base_link so it stays
+                    # anchored on the dock (green reference, no fresh blue).
+                    cc, ss = math.cos(ryaw_o), math.sin(ryaw_o)
+                    self._publish_docking_line_marker(
+                        dxl * cc + dyl * ss, -dxl * ss + dyl * cc,
+                        normalize_angle(norm_o - ryaw_o))
+                else:
+                    omega = 0.0   # no odom line captured yet — fall back to straight
 
             omega = max(-self.drive_yaw_max_omega,
                         min(self.drive_yaw_max_omega, omega))
@@ -1154,20 +1516,28 @@ class DockTrigger(Node):
             omega = self._floor_omega(
                 omega, period, bool(self.get_parameter('omega_pwm').value))
             v = drive_speed
-            taper = 2.0 * self.docking_distance
-            if depth < taper:
-                # Floor the taper at the 0.05 m/s clean stick-slip floor.
-                # Measured (scripts/min_velocity_sweep.py, 2026-07-02): 0.02
-                # stalls, 0.03 judders (a-coups), 0.04 reliable, 0.05 is the
-                # lowest clean speed. The old 0.03 floor sat in the judder band.
-                v = max(0.05, drive_speed * depth / taper)
+            # Slow down as EITHER sensor approaches its stop threshold (closest wins).
+            eff = depth if lidar_dist is None else min(depth, lidar_dist)
+            eff_thresh = max(self.docking_distance, self.stop_lidar_distance)
+            taper = 2.0 * eff_thresh
+            if eff < taper:
+                # Floor the taper at final_push_speed. 0.05 = clean stick-slip floor
+                # (measured min_velocity_sweep 2026-07-02: 0.02 stalls, 0.03 judders,
+                # 0.05 lowest clean). Raise it to carry momentum over the dock step at
+                # low battery. Live-read so it can be tuned mid-dock.
+                v = max(float(self.get_parameter('final_push_speed').value),
+                        drive_speed * eff / taper)
 
             # DEBUG (throttled ~2 Hz, clearer wording 2026-07-07): which tier is
             # actually driving the approach, and whether the normal is frozen.
             now_dbg = time.time()
             if now_dbg - getattr(self, '_p5_dbg', 0.0) > 0.5:
                 self._p5_dbg = now_dbg
-                if est_base is not None:
+                if self.unified_odom_line:
+                    tier = ('UNIFIED (odom-line, 3 tags)' if est_base is not None
+                            else 'UNIFIED (odom-line, centre)' if c1cam is not None
+                            else 'UNIFIED (odom-line, coast)')
+                elif est_base is not None:
                     tier = 'TIER1 (2+ tags)'
                 elif not use_cam and pose is not None and depth > freeze:
                     tier = 'LEGACY (map-frame)'
@@ -1180,11 +1550,13 @@ class DockTrigger(Node):
                           if bnorm_filt is not None else 'n/a')
                 self.get_logger().info(
                     f'   [DOCKING] depth={depth:.2f}m  {tier}  normal={frozen_s} ({norm_s})  '
-                    f'omega={omega:+.2f}rad/s  v={v:.2f}m/s  '
+                    f'lateral={lateral:+.3f}m  omega={omega:+.2f}rad/s  v={v:.2f}m/s  '
                     f'tags_visible={"yes" if c1cam is not None else "no"}  '
                     f'blind_frames={lost_frames}')
             self._publish_cmd_vel(v, omega)
+            self._lateral_pub.publish(Float32(data=float(lateral)))   # robot↔line error, live
             self._publish_gz_line_marker(cx, cy, normal_yaw)
+            self._publish_forward_lidar_points()   # RED: the lidar points the stop looks at
             time.sleep(period)
 
         self._publish_cmd_vel(0.0, 0.0)
@@ -1192,14 +1564,15 @@ class DockTrigger(Node):
         return False
 
     def _estimate_dock_once(self):
-        """One-shot dock estimate (cx, cy, normal_yaw) in the map frame from a
-        single read of the three tags, or None if the outer tags aren't both
-        visible. Used to keep the approach axis adapting in real time."""
-        p0 = self._lookup_tag_map('charging_dock_tag_0')
-        p2 = self._lookup_tag_map('charging_dock_tag_2')
-        if p0 is None or p2 is None:
+        """One-shot dock estimate (cx, cy, normal_yaw) in the MAP frame from a
+        single read of ALL THREE tags (position + facing). Returns None unless the
+        three tags are visible together. Keeps the approach axis adapting in real
+        time."""
+        p0 = self._lookup_tag_map3('charging_dock_tag_0')
+        p1 = self._lookup_tag_map3('charging_dock_tag_1')
+        p2 = self._lookup_tag_map3('charging_dock_tag_2')
+        if p0 is None or p1 is None or p2 is None:
             return None
-        p1 = self._lookup_tag_map('charging_dock_tag_1')
         pose = self.lookup_robot_pose()
         if pose is None:
             return None
@@ -1211,43 +1584,37 @@ class DockTrigger(Node):
         (base_link). Carries NO map (AMCL) or odometry error — the axis is
         expressed relative to the robot, which sits at the origin facing +x.
 
-        Robust to a single outer-tag dropout: with BOTH outer tags it uses their
-        full 52 cm baseline (cleanest normal); with the CENTRE tag + ONE outer it
-        falls back to the half-baseline (centre→outer, collinear with the full tag
-        row) so the perpendicular alignment keeps running when id0 or id2 flickers
-        (the centre tag id1 is the reliably visible one). Returns None only if the
-        centre tag AND both outers are gone. This dropout tolerance is what the
-        earlier version lacked: requiring both outers made est_base None whenever
-        an outer tag dropped, silently reverting the approach to bearing-only
-        (which does not align perpendicular → 'not aligned, lost the tag')."""
-        p0 = self._lookup_tag_base('charging_dock_tag_0')
-        p1 = self._lookup_tag_base('charging_dock_tag_1')
-        p2 = self._lookup_tag_base('charging_dock_tag_2')
+        Requires ALL THREE tags (position + facing): the geometry+orientation
+        normal (see _dock_pose_from_tags) is only trusted from a full three-tag
+        view. If any tag is missing this yields no normal (None) and the caller
+        holds the last valid one — there is deliberately NO half-baseline two-tag
+        fallback (that noisy estimate was a source of the final-approach
+        oscillation)."""
+        p0 = self._lookup_tag_base3('charging_dock_tag_0')
+        p1 = self._lookup_tag_base3('charging_dock_tag_1')
+        p2 = self._lookup_tag_base3('charging_dock_tag_2')
+        if p0 is None or p1 is None or p2 is None:
+            return None
         # Robot is at the origin of base_link → rx = ry = 0.
-        if p0 is not None and p2 is not None:
-            return self._dock_pose_from_tags(p0, p1, p2, 0.0, 0.0)
-        if p1 is None:
-            return None
-        if p2 is not None:
-            return self._dock_pose_from_two(p1, p2)
-        if p0 is not None:
-            return self._dock_pose_from_two(p1, p0)
-        return None
+        return self._dock_pose_from_tags(p0, p1, p2, 0.0, 0.0)
 
-    def _dock_pose_from_two(self, c, o):
-        """Dock pose (cx, cy, normal_yaw) from the CENTRE tag `c` + ONE outer tag
-        `o` (both (x, y) in base_link). Dock centre = the centre tag; the normal is
-        perpendicular to the centre→outer line (collinear with the full tag row),
-        disambiguated toward the robot at the origin. Half-baseline → noisier than
-        the two-outer estimate, but keeps the alignment alive through a dropout."""
-        dx, dy = o[0] - c[0], o[1] - c[1]
-        L = math.hypot(dx, dy)
-        if L < 1e-6:
+    def _estimate_dock_odom_once(self):
+        """3-tag dock estimate (cx, cy, normal_yaw) directly in the ODOM frame —
+        the native frame for the unified dock line. Each tag is looked up in odom
+        LAG-CORRECT (placed where it was at its own detection time), so the fitted
+        line lives world-fixed with no base_link→odom transform through the
+        possibly-lagged current robot pose. Requires all three tags. None if any
+        tag is missing/stale, odom is unavailable, or the agreement gate rejects."""
+        p0 = self._lookup_tag_odom3('charging_dock_tag_0')
+        p1 = self._lookup_tag_odom3('charging_dock_tag_1')
+        p2 = self._lookup_tag_odom3('charging_dock_tag_2')
+        if p0 is None or p1 is None or p2 is None:
             return None
-        nx, ny = -dy / L, dx / L
-        if nx * (0.0 - c[0]) + ny * (0.0 - c[1]) < 0.0:
-            nx, ny = -nx, -ny
-        return c[0], c[1], math.atan2(-ny, -nx)
+        op = self._lookup_odom_pose()
+        if op is None:
+            return None
+        # reference (rx, ry) = robot odom position so the normal points toward it.
+        return self._dock_pose_from_tags(p0, p1, p2, op[0], op[1])
 
     def _floor_omega(self, desired, period, pwm):
         """Map a desired yaw rate to what the geared BLDC can actually execute.
@@ -1305,18 +1672,11 @@ class DockTrigger(Node):
             self.get_logger().error('   undock reverse failed')
             return False
 
-        pose = self.lookup_robot_pose()
-        if pose is None:
-            self.get_logger().error('   could not read robot pose for 180° spin')
-            return False
-        _, _, ryaw = pose
-        target_yaw = normalize_angle(ryaw + math.pi)
-        self.get_logger().info(
-            f'   spinning 180° (from {ryaw:.3f} to {target_yaw:.3f})'
-        )
-        # 180° is the longest spin — give it more time than the default 15 s
-        # (a slow spin_max_omega or collision-monitor clamping can stretch it).
-        if not self._spin_to_yaw(target_yaw, max_time=30.0):
+        # Rough ~180° turn, measured in ODOM (smooth, immune to the AMCL
+        # relocalise jump when the laser correction resumes at undock). Precision
+        # doesn't matter — just get roughly turned around.
+        self.get_logger().info('   spinning ~180° (rough, odom-measured)')
+        if not self._spin_angle_odom(math.pi, max_time=30.0):
             self.get_logger().error('   undock 180° spin failed')
             return False
 
@@ -1336,7 +1696,10 @@ class DockTrigger(Node):
         backward check here.
         """
         period = 1.0 / self.drive_rate_hz
-        pose0 = self.lookup_robot_pose()
+        # Measure travel in ODOM, not map: the map pose JUMPS when AMCL's laser
+        # correction resumes at undock (relocalise), which would spike `travelled`
+        # and cut the reverse short ("doesn't back up 0.7 m"). Odom is smooth.
+        pose0 = self._lookup_odom_pose()
         if pose0 is None:
             return False
         x0, y0, _ = pose0
@@ -1344,7 +1707,7 @@ class DockTrigger(Node):
         deadline = time.time() + dist / speed + max_extra_time
 
         while time.time() < deadline:
-            pose = self.lookup_robot_pose()
+            pose = self._lookup_odom_pose()
             if pose is None:
                 time.sleep(period)
                 continue
@@ -1617,6 +1980,42 @@ class DockTrigger(Node):
         self.get_logger().error('   _spin_to_yaw timeout')
         return False
 
+    def _spin_angle_odom(self, delta_yaw: float, tol: float = 0.15,
+                         max_time: float = 30.0) -> bool:
+        """ROUGH in-place turn by `delta_yaw` rad, measured in ODOM (smooth, no
+        AMCL relocalise jump). Deliberately crude: spin at a fixed firm rate and
+        INTEGRATE the odom yaw change until the total turned reaches |delta_yaw|
+        within a loose tolerance — no precise target heading, no settle band.
+        Used for the undock 180° where precision doesn't matter and robustness
+        (low battery, poor localisation) does."""
+        period = 1.0 / self.drive_rate_hz
+        prev = self._lookup_odom_yaw()
+        if prev is None:
+            return False
+        direction = 1.0 if delta_yaw >= 0.0 else -1.0
+        omega = direction * max(self.spin_min_omega, self.spin_max_omega)
+        target = abs(delta_yaw)
+        turned = 0.0
+        deadline = time.time() + target / max(0.1, abs(omega)) + max_time
+        while time.time() < deadline:
+            yaw = self._lookup_odom_yaw()
+            if yaw is None:
+                time.sleep(period)
+                continue
+            turned += abs(normalize_angle(yaw - prev))   # wrap-safe increment
+            prev = yaw
+            if turned >= target - tol:
+                self._publish_cmd_vel(0.0, 0.0)
+                self.get_logger().info(
+                    f'   rough spin done: turned ~{math.degrees(turned):.0f}°')
+                return True
+            self._publish_cmd_vel(0.0, omega)
+            time.sleep(period)
+        self._publish_cmd_vel(0.0, 0.0)
+        self.get_logger().warn(
+            f'   rough spin timeout (turned ~{math.degrees(turned):.0f}°)')
+        return False
+
     def _drive_to_xy(self, tx: float, ty: float, max_time: float = 60.0) -> bool:
         """Drive forward toward (tx, ty) in map frame, correcting heading along
         the way. Stops when robot is within position_tolerance of (tx, ty)."""
@@ -1822,47 +2221,54 @@ class DockTrigger(Node):
         msg.angular.z = float(omega)
         self.cmd_vel_pub.publish(msg)
 
-    def _publish_docking_line_marker(self, anchor_x: float, anchor_y: float, normal_yaw: float):
-        """Publish the ONE live docking line: the dock's own perpendicular axis
-        (the normal the robot must get onto and follow), anchored at the DOCK's
-        position — not at the robot. Drawn in base_link frame (always available,
-        works across every tier) but anchored at (anchor_x, anchor_y) = the
-        dock/tag position in that frame, exactly like the old map-frame line was
-        anchored at the dock in the map frame — just live now instead of a
-        stale Phase-4 snapshot.
+    def _publish_docking_line_marker(self, anchor_x: float, anchor_y: float,
+                                     normal_yaw: float, current_yaw=None):
+        """Publish the docking normal line(s), anchored at the dock (anchor_x,
+        anchor_y) in base_link:
 
-        2026-07-07 correction: an earlier version of this drew an ARROW
-        starting from the robot's own origin — wrong concept entirely, that's
-        "which way to turn", not "the line the robot must be on". Fixed to a
-        proper line through the dock's actual position.
-
-        anchor_x, anchor_y: dock/tag position, base_link frame.
-        normal_yaw: dock normal direction, base_link frame (0 = robot's current
-        forward) — the robot is correctly docked when it sits ON this line,
-        facing along it.
+          - GREEN (id 0) = the REFERENCE normal (normal_yaw) — the filtered/frozen
+            axis the pure-pursuit actually steers onto;
+          - BLUE (id 2) = the CURRENT raw normal (current_yaw) this frame, when a
+            fresh 3-tag detection exists — so you SEE the live detection wobble
+            against the stable green reference (deleted when no fresh detection);
+          - RED sphere (id 1) = the dock/tag (tag 1) itself.
         """
         if not self.publish_debug_markers:
             return
         now = self.get_clock().now().to_msg()
-        dirx, diry = math.cos(normal_yaw), math.sin(normal_yaw)
         arr = MarkerArray()
 
-        line = Marker()
-        line.header.frame_id = 'base_link'
-        line.header.stamp = now
-        line.ns = 'docking_line'
-        line.id = 0
-        line.type = Marker.LINE_STRIP
-        line.action = Marker.ADD
-        line.scale.x = 0.03
-        line.color.g = 1.0
-        line.color.a = 1.0
-        line.pose.orientation.w = 1.0
-        line.points = [
-            Point(x=anchor_x - 4.0 * dirx, y=anchor_y - 4.0 * diry, z=0.15),
-            Point(x=anchor_x + 0.3 * dirx, y=anchor_y + 0.3 * diry, z=0.15),
-        ]
-        arr.markers.append(line)
+        def _line(mid, yaw, r, g, b, z):
+            dirx, diry = math.cos(yaw), math.sin(yaw)
+            m = Marker()
+            m.header.frame_id = 'base_link'
+            m.header.stamp = now
+            m.ns = 'docking_line'
+            m.id = mid
+            m.type = Marker.LINE_STRIP
+            m.action = Marker.ADD
+            m.scale.x = 0.03
+            m.color.r, m.color.g, m.color.b, m.color.a = r, g, b, 1.0
+            m.pose.orientation.w = 1.0
+            m.points = [
+                Point(x=anchor_x - 4.0 * dirx, y=anchor_y - 4.0 * diry, z=z),
+                Point(x=anchor_x + 0.3 * dirx, y=anchor_y + 0.3 * diry, z=z),
+            ]
+            return m
+
+        # BLUE = current raw detection (drawn first / lower so green stays visible).
+        if current_yaw is not None:
+            arr.markers.append(_line(2, current_yaw, 0.0, 0.0, 1.0, 0.15))
+        else:
+            gone = Marker()
+            gone.header.frame_id = 'base_link'
+            gone.ns = 'docking_line'
+            gone.id = 2
+            gone.action = Marker.DELETE
+            arr.markers.append(gone)
+        # GREEN = reference normal (what the robot steers onto) — drawn ON TOP (after
+        # the blue) so it is always visible, even when it coincides with the blue.
+        arr.markers.append(_line(0, normal_yaw, 0.0, 1.0, 0.0, 0.16))
 
         # Red sphere at the dock/tag itself.
         tag = Marker()
@@ -1881,6 +2287,38 @@ class DockTrigger(Node):
         tag.color.a = 1.0
         arr.markers.append(tag)
 
+        self.marker_pub.publish(arr)
+
+    def _publish_forward_lidar_points(self):
+        """Show, in RED on /docking/debug_markers (id 3), the LiDAR returns inside
+        the FORWARD stop cone — the exact points the lidar-stop looks at, so you can
+        see whether the lidar actually catches the dock."""
+        if not self.publish_debug_markers:
+            return
+        scan = self.latest_scan
+        m = Marker()
+        m.header.frame_id = scan.header.frame_id if scan is not None else 'base_link'
+        m.header.stamp = self.get_clock().now().to_msg()
+        m.ns = 'docking_line'
+        m.id = 3
+        m.type = Marker.POINTS
+        m.scale.x = m.scale.y = 0.04
+        m.color.r = 1.0
+        m.color.a = 1.0
+        m.pose.orientation.w = 1.0
+        if scan is not None:
+            center = self.obstacle_scan_forward_angle
+            half = self.stop_lidar_arc_half
+            floor = max(self.obstacle_min_range, scan.range_min)
+            for i, r in enumerate(scan.ranges):
+                if not math.isfinite(r) or r < floor or r > scan.range_max:
+                    continue
+                a = scan.angle_min + i * scan.angle_increment
+                if abs(math.atan2(math.sin(a - center), math.cos(a - center))) <= half:
+                    m.points.append(Point(x=r * math.cos(a), y=r * math.sin(a), z=0.05))
+        m.action = Marker.ADD if m.points else Marker.DELETE
+        arr = MarkerArray()
+        arr.markers.append(m)
         self.marker_pub.publish(arr)
 
     def _publish_gz_line_marker(self, cx_in: float, cy_in: float, perp_yaw: float):
@@ -1985,6 +2423,33 @@ class DockTrigger(Node):
             return None
         return quat_to_yaw(t.transform.rotation)
 
+    def _lookup_odom_pose(self):
+        """odom->base_link (x, y, yaw) in ONE lookup — the robot pose in the
+        smooth, LiDAR-independent odom frame. Used to freeze the dock line in odom
+        and dead-reckon the robot's offset from it once the tag is lost."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'odom', 'base_link', rclpy.time.Time(),
+                timeout=Duration(seconds=0.1))
+        except Exception:
+            return None
+        return (t.transform.translation.x, t.transform.translation.y,
+                quat_to_yaw(t.transform.rotation))
+
+    def _snapshot_odom_line(self, bax, bay, bnorm):
+        """Freeze the current base_link dock line (anchor bax,bay + normal bnorm)
+        into the ODOM frame, so it stays world-fixed on the dock when the tag is
+        later lost — tier 3 then steers on it via odometry (arrives straight) and
+        the marker stays put instead of sliding with the robot."""
+        op = self._lookup_odom_pose()
+        if op is None:
+            return
+        rx_o, ry_o, ryaw_o = op
+        c, s = math.cos(ryaw_o), math.sin(ryaw_o)
+        self._odom_line = (rx_o + bax * c - bay * s,
+                           ry_o + bax * s + bay * c,
+                           normalize_angle(bnorm + ryaw_o))
+
     # ── Multi-tag perception (3 tags: id0/id2 outer, id1 centre) ──────────
     def _lookup_tag_cam(self, frame):
         """3D position (x, y, z) of `frame` in camera_optical_frame, or None if
@@ -2031,6 +2496,64 @@ class DockTrigger(Node):
         if age > self.detection_max_age:
             return None
         return (t.transform.translation.x, t.transform.translation.y)
+
+    @staticmethod
+    def _tf_tag_yaw(t):
+        """Ground-plane yaw of a tag's facing direction (its +Z axis) from a
+        looked-up transform, expressed in that transform's target frame."""
+        q = t.transform.rotation
+        nx, ny, _ = quat_rotate_z(q.x, q.y, q.z, q.w)
+        return math.atan2(ny, nx)
+
+    def _lookup_tag_base3(self, frame):
+        """(x, y, yaw) of `frame` in base_link — position AND facing yaw (the tag
+        +Z axis projected to the ground). None if the TF is missing/stale."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'base_link', frame, rclpy.time.Time(),
+                timeout=Duration(seconds=0.1))
+        except Exception:
+            return None
+        age = (self.get_clock().now()
+               - rclpy.time.Time.from_msg(t.header.stamp)).nanoseconds * 1e-9
+        if age > self.detection_max_age:
+            return None
+        return (t.transform.translation.x, t.transform.translation.y,
+                self._tf_tag_yaw(t))
+
+    def _lookup_tag_odom3(self, frame):
+        """(x, y, yaw) of `frame` in the ODOM frame — LAG-CORRECT: tf2 resolves
+        odom←base_link at the tag's OWN detection timestamp (Time(0) = latest
+        common time = the tag stamp), so the tag is placed where it actually was
+        when the camera saw it, not dragged along by the robot that moved during
+        the camera latency. None if the TF is missing/stale (or odom lacks that
+        timestamp)."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'odom', frame, rclpy.time.Time(), timeout=Duration(seconds=0.1))
+        except Exception:
+            return None
+        age = (self.get_clock().now()
+               - rclpy.time.Time.from_msg(t.header.stamp)).nanoseconds * 1e-9
+        if age > self.detection_max_age:
+            return None
+        return (t.transform.translation.x, t.transform.translation.y,
+                self._tf_tag_yaw(t))
+
+    def _lookup_tag_map3(self, frame):
+        """(x, y, yaw) of `frame` in the map frame — position AND facing yaw.
+        None if the TF is missing/stale."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'map', frame, rclpy.time.Time(), timeout=Duration(seconds=0.2))
+        except Exception:
+            return None
+        age = (self.get_clock().now()
+               - rclpy.time.Time.from_msg(t.header.stamp)).nanoseconds * 1e-9
+        if age > self.detection_max_age:
+            return None
+        return (t.transform.translation.x, t.transform.translation.y,
+                self._tf_tag_yaw(t))
 
     def _dock_center_cam(self, require_all=True):
         """The CENTRE tag (id1) in camera_optical_frame — the thing we centre

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -1044,6 +1044,7 @@ class DockTrigger(Node):
                 desired_yaw = normalize_angle(
                     bnorm_filt - math.atan2(blat_filt, lookahead))
                 omega = line_kp * desired_yaw
+                self._publish_base_link_normal_marker(bnorm_filt, blat_filt, 'FAR-cam avg')
             elif (not use_cam) and pose is not None and depth > freeze:
                 rx, ry, ryaw = pose
                 # LEGACY map-frame FAR leg (use_camera_frame_normal:=false): the
@@ -1158,6 +1159,7 @@ class DockTrigger(Node):
                         else:
                             d_desired = (desired_yaw - prev_desired_yaw) / dt
                         last_valid_t = now_t
+                    self._publish_base_link_normal_marker(ref_yaw, lateral_filt, 'NEAR carried')
                     # Hysteresis deadband: drive straight while aligned, only
                     # commit a correction past the outer band, release at the
                     # inner band. Stops the per-frame left-right hunting; the
@@ -1901,6 +1903,70 @@ class DockTrigger(Node):
         tag.color.r = 1.0
         tag.color.a = 1.0
         arr.markers.append(tag)
+
+        self.marker_pub.publish(arr)
+
+    def _publish_base_link_normal_marker(self, normal_yaw: float, lateral: float, label: str):
+        """Publish the LIVE dock-normal estimate actually driving the controller,
+        as an arrow in base_link frame (robot always has this frame, so it works
+        during camera-frame FAR and NEAR alike, unlike _publish_line_markers'
+        map-frame cx/cy/normal_yaw — which, on the real robot
+        (use_camera_frame_normal:=true), are the STALE Phase-4 estimate, never
+        updated by the live bnorm_filt EMA that's actually steering the robot.
+
+        Added 2026-07-07 after a real-robot test where the final heading was
+        wrong despite converging onto the line ("sur la normale mais pas la
+        bonne orientation") — this lets the operator watch in RViz whether the
+        normal estimate is stable (well-averaged) or noisy in real time, which
+        the old map-frame marker could never show for the camera-frame path.
+
+        normal_yaw: dock normal, base_link frame (0 = robot's current forward).
+        lateral: signed lateral offset (m) at the current lookahead, for the dot.
+        label: 'FAR-cam avg' or 'NEAR carried', kept as the marker ns for clarity.
+        """
+        if not self.publish_debug_markers:
+            return
+        now = self.get_clock().now().to_msg()
+        arr = MarkerArray()
+
+        arrow = Marker()
+        arrow.header.frame_id = 'base_link'
+        arrow.header.stamp = now
+        arrow.ns = f'dock_normal_live_{label}'
+        arrow.id = 0
+        arrow.type = Marker.ARROW
+        arrow.action = Marker.ADD
+        arrow.points = [
+            Point(x=0.0, y=0.0, z=0.25),
+            Point(x=1.0 * math.cos(normal_yaw), y=1.0 * math.sin(normal_yaw), z=0.25),
+        ]
+        arrow.scale.x = 0.04   # shaft diameter
+        arrow.scale.y = 0.08   # head diameter
+        arrow.scale.z = 0.12   # head length
+        arrow.color.b = 1.0
+        arrow.color.g = 1.0    # cyan — distinct from the green map-frame line
+        arrow.color.a = 1.0
+        arrow.pose.orientation.w = 1.0
+        arr.markers.append(arrow)
+
+        # Small magenta dot at the lateral offset, lookahead metres ahead —
+        # the point the pure-pursuit law is actually steering toward.
+        dot = Marker()
+        dot.header.frame_id = 'base_link'
+        dot.header.stamp = now
+        dot.ns = f'dock_normal_live_{label}'
+        dot.id = 1
+        dot.type = Marker.SPHERE
+        dot.action = Marker.ADD
+        dot.pose.position.x = 0.7
+        dot.pose.position.y = -lateral   # camera +X (right) = base_link -Y
+        dot.pose.position.z = 0.25
+        dot.pose.orientation.w = 1.0
+        dot.scale.x = dot.scale.y = dot.scale.z = 0.06
+        dot.color.r = 1.0
+        dot.color.b = 1.0
+        dot.color.a = 1.0
+        arr.markers.append(dot)
 
         self.marker_pub.publish(arr)
 

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -924,6 +924,7 @@ class DockTrigger(Node):
         blat_filt = None       # EMA of the lateral offset from the dock axis, tier 1
         carried_norm = None     # freshest bnorm_filt, carried forward for tier 2
         carried_odom_yaw = None  # odom yaw at the moment carried_norm was last set
+        lateral_t2_filt = None   # EMA of tier 2's lateral offset (reset on tier switch)
         lost_frames = 0          # consecutive fully-blind (tier 3) frames
         last_cam_depth = None       # last camera depth to tag 1 (odom dead-reckoning)
         last_odom = None            # odom xy captured with last_cam_depth
@@ -1003,15 +1004,29 @@ class DockTrigger(Node):
                 spike = float(self.get_parameter('axis_spike_reject').value)
                 if bnorm_filt is None:
                     bnorm_filt, blat_filt = byaw, lateral
-                elif abs(normalize_angle(byaw - bnorm_filt)) <= spike:
-                    bnorm_filt = normalize_angle(
-                        bnorm_filt + a_n * normalize_angle(byaw - bnorm_filt))
-                    blat_filt = (1.0 - a_n) * blat_filt + a_n * lateral
-                # else: spike — keep the last filtered normal this frame
+                else:
+                    dev = abs(normalize_angle(byaw - bnorm_filt))
+                    if dev <= spike:
+                        # Stability weighting: a sample close to the CURRENT running
+                        # average (i.e. consistent with recent history) gets close to
+                        # full trust (a_n); one that disagrees more — but not enough to
+                        # be a hard-rejected spike — is damped instead of fully
+                        # incorporated. A single noisy reading can no longer yank the
+                        # axis around on its own: only a RUN of mutually-agreeing
+                        # samples builds real influence (each keeps dev small once the
+                        # filter has moved toward them, so their weight stays high).
+                        # True outliers (dev > spike) are still hard-rejected, unchanged.
+                        stability = max(0.15, 1.0 - dev / spike)
+                        a_eff = a_n * stability
+                        bnorm_filt = normalize_angle(
+                            bnorm_filt + a_eff * normalize_angle(byaw - bnorm_filt))
+                        blat_filt = (1.0 - a_eff) * blat_filt + a_eff * lateral
+                    # else: spike — keep the last filtered normal this frame
                 desired_yaw = normalize_angle(
                     bnorm_filt - math.atan2(blat_filt, lookahead))
                 omega = line_kp * desired_yaw
                 lost_frames = 0
+                lateral_t2_filt = None   # reset tier 2's smoother — see tier 2 below
                 # Keep the carried snapshot fresh for whenever tier 1 drops out
                 # (outer tags leave the FOV) — always the LATEST good axis, not a
                 # one-time freeze, so tier 2 picks up from the best data available.
@@ -1056,7 +1071,23 @@ class DockTrigger(Node):
                     if odom_yaw_now is not None:
                         ref_yaw = normalize_angle(
                             carried_norm - (odom_yaw_now - carried_odom_yaw))
-                lateral = c1cam[0]   # metric lateral offset (m) — solvePnP translation
+                lateral_raw = c1cam[0]   # metric lateral offset (m) — solvePnP translation
+                # Same stability-weighted smoothing idea as tier 1's bnorm_filt, applied
+                # to the lateral offset (tier 2 has no orientation to average, only this).
+                # Reset to None whenever tier 2 wasn't active last loop (see tier 1 and
+                # tier 3), so it always starts fresh on entry rather than risking getting
+                # stuck comparing against a stale value from a much earlier tier-2 spell.
+                if lateral_t2_filt is None:
+                    lateral_t2_filt = lateral_raw
+                else:
+                    dev2 = abs(lateral_raw - lateral_t2_filt)
+                    spike2 = 0.15   # m — generous single-frame lateral jump reject
+                    if dev2 <= spike2:
+                        stability2 = max(0.15, 1.0 - dev2 / spike2)
+                        a2 = 0.3 * stability2
+                        lateral_t2_filt = (1.0 - a2) * lateral_t2_filt + a2 * lateral_raw
+                    # else: spike — keep the last filtered lateral this frame
+                lateral = lateral_t2_filt
                 desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral, lookahead))
                 omega = line_kp * desired_yaw
                 lost_frames = 0
@@ -1067,6 +1098,7 @@ class DockTrigger(Node):
                 # odometry above, so 'docked' still triggers correctly.
                 lost_frames += 1
                 omega = 0.0
+                lateral_t2_filt = None   # reset tier 2's smoother — see tier 2 above
 
             omega = max(-self.drive_yaw_max_omega,
                         min(self.drive_yaw_max_omega, omega))
@@ -1815,7 +1847,7 @@ class DockTrigger(Node):
         arrow = Marker()
         arrow.header.frame_id = 'base_link'
         arrow.header.stamp = now
-        arrow.ns = f'dock_normal_live_{label}'
+        arrow.ns = 'dock_normal_live'
         arrow.id = 0
         arrow.type = Marker.ARROW
         arrow.action = Marker.ADD
@@ -1837,7 +1869,7 @@ class DockTrigger(Node):
         dot = Marker()
         dot.header.frame_id = 'base_link'
         dot.header.stamp = now
-        dot.ns = f'dock_normal_live_{label}'
+        dot.ns = 'dock_normal_live'
         dot.id = 1
         dot.type = Marker.SPHERE
         dot.action = Marker.ADD

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -49,6 +49,8 @@ from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.parameter_client import AsyncParameterClient
+from lifecycle_msgs.srv import ChangeState
+from lifecycle_msgs.msg import Transition
 
 from std_msgs.msg import Bool, String, Float32
 from std_srvs.srv import SetBool, Empty
@@ -298,6 +300,12 @@ class DockTrigger(Node):
         # folding in scans, so map->odom is propagated on ODOMETRY only (smooth, no relocalisation
         # jumps when nearby objects have moved). Restored on dock end/abort. See docs/13_perception.
         self.declare_parameter('pause_amcl_during_dock', True)
+        # Deactivate Nav2's collision_monitor for the dock: it sees the dock in its
+        # stop zone and publishes zero on /cmd_vel, fighting dock_trigger's forward
+        # command (both publish /cmd_vel) → the robot stalls ~15 cm out. Kept ON for
+        # normal navigation, OFF only during the maneuver.
+        self.declare_parameter('pause_collision_monitor_during_dock', True)
+        self.declare_parameter('collision_monitor_node', '/collision_monitor')
         self.declare_parameter('amcl_pause_min_d', 1000.0)       # m  — huge = AMCL never laser-updates
         self.declare_parameter('amcl_pause_min_a', 1000.0)       # rad
         self.declare_parameter('amcl_resume_min_d', 0.25)        # m  — AMCL default, restored after
@@ -442,6 +450,11 @@ class DockTrigger(Node):
         self.amcl_resume_min_a = float(self.get_parameter('amcl_resume_min_a').value)
         self._amcl_paused = False
         self._amcl_param_cli = AsyncParameterClient(self, 'amcl')
+        self.pause_collision_monitor_during_dock = bool(
+            self.get_parameter('pause_collision_monitor_during_dock').value)
+        colmon = str(self.get_parameter('collision_monitor_node').value).rstrip('/')
+        self._colmon_cli = self.create_client(ChangeState, f'{colmon}/change_state')
+        self._colmon_paused = False
         self.obs_lateral = float(self.get_parameter('obs_lateral').value)
         self.obs_distance = float(self.get_parameter('obs_distance').value)
         self.freeze_axis_distance = float(self.get_parameter('freeze_axis_distance').value)
@@ -804,6 +817,46 @@ class DockTrigger(Node):
         self._amcl_paused = False
         self.get_logger().info('AMCL laser correction RESUMED.')
 
+    def _set_collision_monitor(self, active: bool) -> bool:
+        """Activate/deactivate Nav2's collision_monitor via its lifecycle service.
+        During docking we DEACTIVATE it: it otherwise sees the dock in its stop
+        zone and publishes zero on /cmd_vel, which fights dock_trigger's forward
+        command (both publish /cmd_vel) → the robot judders and stalls ~15 cm from
+        the dock. Fire-and-forget (don't block the sequence on the result)."""
+        if not self.pause_collision_monitor_during_dock:
+            return False
+        try:
+            if not self._colmon_cli.wait_for_service(timeout_sec=2.0):
+                self.get_logger().warn(
+                    'collision_monitor lifecycle service unavailable — skipping '
+                    'its pause (it may stall the final approach).')
+                return False
+            req = ChangeState.Request()
+            req.transition.id = (Transition.TRANSITION_ACTIVATE if active
+                                 else Transition.TRANSITION_DEACTIVATE)
+            self._colmon_cli.call_async(req)
+            return True
+        except Exception as e:
+            self.get_logger().warn(f'collision_monitor state change failed: {e}')
+            return False
+
+    def _pause_collision_monitor(self):
+        """Deactivate the collision_monitor for the dock (it fights /cmd_vel and
+        stalls the approach ~15 cm out)."""
+        if self._set_collision_monitor(False):
+            self._colmon_paused = True
+            self.get_logger().info(
+                'collision_monitor DEACTIVATED for the dock (it was stopping the '
+                'approach ~15 cm out).')
+
+    def _resume_collision_monitor(self):
+        """Re-activate the collision_monitor after the dock (idempotent)."""
+        if not self._colmon_paused:
+            return
+        self._set_collision_monitor(True)
+        self._colmon_paused = False
+        self.get_logger().info('collision_monitor RE-ACTIVATED.')
+
     def _marker_tick(self):
         """While docking (but OUTSIDE the NEAR loop, which draws its own marker),
         publish the live dock normal as soon as the 3 tags are visible — so the
@@ -827,6 +880,7 @@ class DockTrigger(Node):
         self._pub_status('docking')
         self._docking_active = True   # timer draws the normal from Phase 2/3 on
         self._pause_amcl()          # freeze map->odom: no relocalisation jumps during the maneuver
+        self._pause_collision_monitor()   # it fights /cmd_vel and stalls the approach ~15 cm out
         try:
             self.run_docking_sequence()
         except Exception as e:
@@ -834,6 +888,7 @@ class DockTrigger(Node):
         finally:
             self._docking_active = False   # stop the Phase 2/3 marker timer
             self._resume_amcl()     # AMCL laser correction back on (success, abort, or exception)
+            self._resume_collision_monitor()   # collision_monitor back on for normal nav
             self._set_apriltag(False)   # apriltag back to ~0% CPU
             if self.stop_lidar_in_approach:
                 self._set_lidar(True)   # LiDAR back on (only if we stopped it)

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -1062,7 +1062,7 @@ class DockTrigger(Node):
                 omega = line_kp * desired_yaw
                 lost_frames = 0
                 lateral_t2_filt = None   # reset tier 2's smoother — see tier 2 below
-                self._publish_base_link_normal_marker(bnorm_filt, blat_filt, 'axis (2+ tags)')
+                self._publish_docking_line_marker(bcx, bcy, bnorm_filt)
             elif (not use_cam) and pose is not None and depth > freeze:
                 rx, ry, ryaw = pose
                 # LEGACY map-frame leg (use_camera_frame_normal:=false): the
@@ -1127,7 +1127,13 @@ class DockTrigger(Node):
                 desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral, lookahead))
                 omega = line_kp * desired_yaw
                 lost_frames = 0
-                self._publish_base_link_normal_marker(ref_yaw, lateral, 'centre-only carried')
+                # Anchor the line marker at the centre tag's own base_link position
+                # (only point still directly measurable in tier 2) rather than at
+                # the robot — skip the publish this loop if that TF is momentarily
+                # unavailable (marker just holds its last position in RViz).
+                p1_base = self._lookup_tag_base('charging_dock_tag_1')
+                if p1_base is not None:
+                    self._publish_docking_line_marker(p1_base[0], p1_base[1], ref_yaw)
             else:
                 # Tier 3 — nothing visible at all: go BLIND. No steering attempt,
                 # just keep advancing straight; depth is dead-reckoned from
@@ -1813,64 +1819,64 @@ class DockTrigger(Node):
         msg.angular.z = float(omega)
         self.cmd_vel_pub.publish(msg)
 
-    def _publish_base_link_normal_marker(self, normal_yaw: float, lateral: float, label: str):
-        """Publish the ONE live dock-normal line actually driving the controller,
-        as an arrow in base_link frame (robot always has this frame, so it works
-        across every tier). There used to ALSO be a map-frame RViz line
-        (_publish_line_markers, removed 2026-07-07) fed by cx/cy/normal_yaw —
-        which, on the real robot (use_camera_frame_normal:=true), was a STALE
-        Phase-4 snapshot, never updated by the live estimate that actually
-        steers the robot. That stale marker + this one being cyan gave two
-        conflicting lines in RViz. Now there is only this one: green.
+    def _publish_docking_line_marker(self, anchor_x: float, anchor_y: float, normal_yaw: float):
+        """Publish the ONE live docking line: the dock's own perpendicular axis
+        (the normal the robot must get onto and follow), anchored at the DOCK's
+        position — not at the robot. Drawn in base_link frame (always available,
+        works across every tier) but anchored at (anchor_x, anchor_y) = the
+        dock/tag position in that frame, exactly like the old map-frame line was
+        anchored at the dock in the map frame — just live now instead of a
+        stale Phase-4 snapshot.
 
-        normal_yaw: dock normal, base_link frame (0 = robot's current forward).
-        lateral: signed lateral offset (m) at the current lookahead, for the dot.
-        label: 'axis (2+ tags)' or 'centre-only carried' — informational only,
-        NOT part of the marker namespace (a namespace-per-label bug briefly
-        caused two simultaneous arrows when the tier flickered; fixed to a
-        single constant namespace so a newer publish always replaces the old).
+        2026-07-07 correction: an earlier version of this drew an ARROW
+        starting from the robot's own origin — wrong concept entirely, that's
+        "which way to turn", not "the line the robot must be on". Fixed to a
+        proper line through the dock's actual position.
+
+        anchor_x, anchor_y: dock/tag position, base_link frame.
+        normal_yaw: dock normal direction, base_link frame (0 = robot's current
+        forward) — the robot is correctly docked when it sits ON this line,
+        facing along it.
         """
         if not self.publish_debug_markers:
             return
         now = self.get_clock().now().to_msg()
+        dirx, diry = math.cos(normal_yaw), math.sin(normal_yaw)
         arr = MarkerArray()
 
-        arrow = Marker()
-        arrow.header.frame_id = 'base_link'
-        arrow.header.stamp = now
-        arrow.ns = 'docking_line'
-        arrow.id = 0
-        arrow.type = Marker.ARROW
-        arrow.action = Marker.ADD
-        arrow.points = [
-            Point(x=0.0, y=0.0, z=0.25),
-            Point(x=1.0 * math.cos(normal_yaw), y=1.0 * math.sin(normal_yaw), z=0.25),
+        line = Marker()
+        line.header.frame_id = 'base_link'
+        line.header.stamp = now
+        line.ns = 'docking_line'
+        line.id = 0
+        line.type = Marker.LINE_STRIP
+        line.action = Marker.ADD
+        line.scale.x = 0.03
+        line.color.g = 1.0
+        line.color.a = 1.0
+        line.pose.orientation.w = 1.0
+        line.points = [
+            Point(x=anchor_x - 4.0 * dirx, y=anchor_y - 4.0 * diry, z=0.15),
+            Point(x=anchor_x + 0.3 * dirx, y=anchor_y + 0.3 * diry, z=0.15),
         ]
-        arrow.scale.x = 0.04   # shaft diameter
-        arrow.scale.y = 0.08   # head diameter
-        arrow.scale.z = 0.12   # head length
-        arrow.color.g = 1.0    # green — the one and only docking line
-        arrow.color.a = 1.0
-        arrow.pose.orientation.w = 1.0
-        arr.markers.append(arrow)
+        arr.markers.append(line)
 
-        # Small red dot at the lateral offset, lookahead metres ahead — the
-        # point the pure-pursuit law is actually steering toward.
-        dot = Marker()
-        dot.header.frame_id = 'base_link'
-        dot.header.stamp = now
-        dot.ns = 'docking_line'
-        dot.id = 1
-        dot.type = Marker.SPHERE
-        dot.action = Marker.ADD
-        dot.pose.position.x = 0.7
-        dot.pose.position.y = -lateral   # camera +X (right) = base_link -Y
-        dot.pose.position.z = 0.25
-        dot.pose.orientation.w = 1.0
-        dot.scale.x = dot.scale.y = dot.scale.z = 0.06
-        dot.color.r = 1.0
-        dot.color.a = 1.0
-        arr.markers.append(dot)
+        # Red sphere at the dock/tag itself.
+        tag = Marker()
+        tag.header.frame_id = 'base_link'
+        tag.header.stamp = now
+        tag.ns = 'docking_line'
+        tag.id = 1
+        tag.type = Marker.SPHERE
+        tag.action = Marker.ADD
+        tag.pose.position.x = anchor_x
+        tag.pose.position.y = anchor_y
+        tag.pose.position.z = 0.20
+        tag.pose.orientation.w = 1.0
+        tag.scale.x = tag.scale.y = tag.scale.z = 0.10
+        tag.color.r = 1.0
+        tag.color.a = 1.0
+        arr.markers.append(tag)
 
         self.marker_pub.publish(arr)
 

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -16,12 +16,12 @@ Sequence on /dock_trigger=true:
   4. Pure-pursuit the normal axis in the camera/tag frame (independent of
      map drift and wheel slip), with a re-verification step against
      normal_tolerance_deg
-  5. Two-regime final approach:
-       FAR  (camera→centre-tag depth > freeze_axis_distance): EMA-average
-            the live axis and pure-pursuit it
-       NEAR (depth ≤ freeze_axis_distance): freeze the averaged axis and
-            finish on a visual corrector on the centre tag
-       — stops when camera→centre-tag depth ≤ docking_distance.
+  5. Final approach (see _final_visual_approach docstring): follow the best
+     available axis estimate (2+ tags EMA-averaged, or the last good axis
+     carried forward via odometry once only the centre tag is visible),
+     same pure-pursuit law throughout; go blind (no correction, just
+     advance) the moment nothing is visible at all — stops when
+     camera→centre-tag depth ≤ docking_distance.
 
 Also supports:
   - /undock_robot → reverse undock_reverse_distance, then spin 180°
@@ -164,50 +164,24 @@ class DockTrigger(Node):
         self.declare_parameter('line_yaw_kp', 2.5)
         self.declare_parameter('line_lookahead_distance', 0.4)
 
-        # Image-frame visual servo (camera-frame closed-loop on the centre
-        # tag) used by the Phase 5 NEAR regime once the axis is frozen.
-        #
-        #     desired_yaw = -atan2(lateral, visual_servo_lookahead)
-        #     omega       = visual_servo_kp · desired_yaw + visual_servo_kd · d(desired_yaw)/dt
-        #
-        # `lateral` = c1cam[0], the tag's metric X translation in
-        # camera_optical_frame (solvePnP, already in metres — NOT a
-        # normalised image coordinate). Using a FIXED lookahead (like FAR's
-        # line_lookahead_distance) instead of the raw bearing atan2(X, Z)
-        # matters: atan2(X, Z) grows mechanically as depth Z shrinks for a
-        # CONSTANT physical lateral offset, so the old bearing-only P-term
-        # intensified purely from getting closer — not from any real
-        # drift — producing the worst corrections right at the end of the
-        # approach (2026-07-07 oscillation audit). Defaulted equal to
-        # freeze_axis_distance so desired_yaw is continuous across the
-        # FAR→NEAR hand-over (depth ≈ freeze_axis_distance right at the
-        # switch, so atan2(lateral, lookahead) ≈ atan2(lateral, depth) at
-        # that instant — no command jump).
-        #
-        # Map-frame solvePnP carries a systematic bias in the near field
-        # (corners hugging the bottom of the FOV), but the image-frame
-        # angle is self-consistent — keeping the tag centred in the
-        # image = aiming straight at the dock. The low-pass filter
-        # alpha rejects single-frame solvePnP spikes (alpha = 0.2 →
-        # time constant ≈ 5 frames; alpha = 1.0 disables filtering).
-        self.declare_parameter('visual_servo_kp', 1.0)            # rad/s per rad
-        self.declare_parameter('visual_servo_lookahead', 0.70)    # m — see rationale above
+        # ── DEAD PARAMS (kept declared only, unused since 2026-07-07) ──────
+        # These drove the old PD visual-servo corrector in _final_visual_approach
+        # (bearing/lateral P+D, deadband hysteresis, lost-frame abort). Dropped in
+        # favour of a simpler tiered approach: follow the best available axis
+        # estimate (2+ tags, or the carried axis with just the centre tag) with
+        # the SAME pure-pursuit law as the far-range leg (line_yaw_kp,
+        # line_lookahead_distance — no separate gains), and go blind (no
+        # correction, just advance) the moment nothing is visible at all. See
+        # _final_visual_approach's docstring for the current logic. Left declared
+        # (not removed) only so existing yaml configs setting them don't error at
+        # startup — safe to delete here and from config/dock_trigger.yaml later.
+        self.declare_parameter('visual_servo_kp', 1.0)
+        self.declare_parameter('visual_servo_lookahead', 0.70)
         self.declare_parameter('visual_servo_filter_alpha', 0.2)
-        # PD + robustness terms for the visual corrector (Phase 5 NEAR). kd
-        # damps the bearing so a lively kp does not zig-zag; max_step rejects
-        # single-frame solvePnP bearing jumps; lost_max_frames bounds how long
-        # tag 1 may stay undetected before the approach aborts (rather than
-        # driving blind).
-        self.declare_parameter('visual_servo_kd', 0.2)           # rad/s per rad/s — damping
-        self.declare_parameter('visual_servo_max_step', 0.35)    # rad — reject bearing flicker
-        self.declare_parameter('visual_lost_max_frames', 15)     # frames lost before abort
-        # Alignment deadband (hysteresis) for the visual corrector: drive
-        # STRAIGHT while the bearing is within the inner band, only commit a
-        # correction once it exceeds the outer band, release again at the inner
-        # band. This — not a per-frame stiction-floor snap — is what stops the
-        # left-right hunting: corrections become gentle engaged arcs, not a
-        # 20 Hz pulse train. Inner band = 0.4 x outer.
-        self.declare_parameter('visual_align_deadband', 0.10)    # rad (~5.7 deg) outer band
+        self.declare_parameter('visual_servo_kd', 0.2)
+        self.declare_parameter('visual_servo_max_step', 0.35)
+        self.declare_parameter('visual_lost_max_frames', 15)
+        self.declare_parameter('visual_align_deadband', 0.10)
         # Sigma-delta PWM of the yaw command so a SUB-FLOOR correction executes as
         # a gentle pulsed turn instead of snapping to the ±min_turn_omega stiction
         # floor (a hard snap gives the ±0.15 rad/s left-right limit cycle around the
@@ -301,11 +275,10 @@ class DockTrigger(Node):
         self.declare_parameter('normal_tolerance_deg', 5.0)      # deg — N vs N' agreement
         self.declare_parameter('obs_lateral', 0.5)               # m — side offset for obs B
         self.declare_parameter('obs_distance', 2.0)              # m from tag for obs B
-        # Phase 5 two regimes: FAR (> freeze_axis_distance) the robot averages
-        # the dock axis from the 3 tags and pure-pursuits it; NEAR (≤ this) the
-        # axis is frozen (no more averaging — close-range estimates are noisy)
-        # and the robot finishes on the centre-tag visual corrector. Camera→tag
-        # depth.
+        # Only gates the LEGACY map-frame leg of _final_visual_approach
+        # (use_camera_frame_normal:=false, unused on the real robot). The
+        # camera-frame path (default) no longer has a FAR/NEAR distance
+        # hand-over — see _final_visual_approach's docstring (2026-07-07).
         self.declare_parameter('freeze_axis_distance', 0.70)     # m camera→tag
         # EMA weight for the live axis estimate (Phase 5 FAR). A cumulative mean
         # would freeze the early (off-axis, wrong) estimates; an EMA keeps
@@ -912,19 +885,31 @@ class DockTrigger(Node):
 
 
     def _final_visual_approach(self, cx, cy, normal_yaw, max_time=90.0):
-        """Two-regime final approach.
+        """Final approach — simplified 2026-07-07 (drop the PD visual corrector).
 
-        FAR (camera depth > freeze_axis_distance): the axis (dock centre +
-        normal) is re-derived every iteration from the live 3-tag perception and
-        folded into a **running average**, and the robot pure-pursuits that axis
-        — so it converges onto the perpendicular line while still far, where the
-        estimate is clean.
+        Three tiers, degrading gracefully with what's currently visible:
 
-        NEAR (≤ freeze_axis_distance): the averaged axis is **frozen** (close-up
-        estimates are noisy and the outer tags start leaving the FOV — averaging
-        them in caused the end-of-approach zig-zag). The robot finishes on the
-        **centre-tag visual corrector** (keep the centre tag centred in the
-        image), which from an already-aligned pose only trims the residual.
+          1. 2+ tags (both outer, or centre+one outer via
+             _estimate_dock_base_once): full ROBOT-FRAME dock-normal
+             pure-pursuit, EMA-averaged — the most robust axis estimate,
+             used for as much of the approach as it's available ("follow
+             the line to the max").
+          2. Only the centre tag visible: no fresh axis estimate possible
+             (a single point has no orientation), so steer using the LAST
+             good axis from tier 1 ("carried"), corrected for however much
+             the robot has turned since via odometry (wheel+IMU EKF,
+             LiDAR-independent) — same pure-pursuit law, same gain, no
+             separate PD/deadband/derivative machinery.
+          3. Nothing visible at all: go BLIND — no steering correction,
+             just keep advancing straight. Depth is dead-reckoned from
+             odometry so 'docked' (depth ≤ docking_distance) still
+             triggers correctly.
+
+        Previously this had a distance-based FAR/NEAR hand-over with a
+        separate bearing-based PD corrector (kp/kd/deadband/PWM) once close.
+        Dropped in favour of the above — simpler and, per real-hardware
+        testing, more predictable: it either has a real axis estimate to
+        follow or it doesn't; no separate "fine correction" regime to tune.
 
         Stops when camera→centre-tag depth ≤ docking_distance.
         """
@@ -935,20 +920,11 @@ class DockTrigger(Node):
         acx, acy = cx, cy
         asin, acos = math.sin(normal_yaw), math.cos(normal_yaw)
         n = 1
-        frozen = False
-        filtered_angle = None    # EMA of raw bearing atan2(X,Z) — kept ONLY as the
-                                  # frame-trustworthiness gate (visual_servo_max_step), not
-                                  # fed into the steering law (see lateral_filt below).
-        lateral_filt = None      # EMA of the metric lateral offset (c1cam[0], m) — the
-                                  # actual NEAR steering signal (depth-independent).
-        last_valid_t = None     # wall-clock time filtered_angle was last actually updated
-        bnorm_at_freeze = None   # bnorm_filt snapshotted at the FAR->NEAR hand-over
-        odom_yaw_at_freeze = None  # odom yaw at that same instant — lets NEAR carry the
-                                    # dock normal forward via odometry (see _lookup_odom_yaw)
-        bnorm_filt = None      # EMA of the ROBOT-frame dock normal (byaw), Phase-5 FAR
-        blat_filt = None       # EMA of the lateral offset from the dock axis
-        lost_frames = 0
-        correcting = False
+        bnorm_filt = None      # EMA of the ROBOT-frame dock normal (byaw), tier 1
+        blat_filt = None       # EMA of the lateral offset from the dock axis, tier 1
+        carried_norm = None     # freshest bnorm_filt, carried forward for tier 2
+        carried_odom_yaw = None  # odom yaw at the moment carried_norm was last set
+        lost_frames = 0          # consecutive fully-blind (tier 3) frames
         last_cam_depth = None       # last camera depth to tag 1 (odom dead-reckoning)
         last_odom = None            # odom xy captured with last_cam_depth
 
@@ -960,10 +936,11 @@ class DockTrigger(Node):
         last_depth = max(0.0, math.hypot(cx - x0, cy - y0) - camera_forward_offset)
 
         while time.time() < deadline:
-            # Pose is OPTIONAL here (short timeout, quiet): once the LiDAR is cut
-            # at the FAR->NEAR hand-over the map→odom TF ages out, and blocking on
-            # it would stall the advance. NEAR runs on the camera alone; pose only
-            # serves FAR (LiDAR still on) and a fallback.
+            # Pose is OPTIONAL here (short timeout, quiet): once close, map→odom
+            # may age out (AMCL/costmaps not trusted this near the dock anyway),
+            # and blocking on it would stall the advance. The approach runs on
+            # the camera + odometry; pose only serves the legacy map-frame leg
+            # and the travel-safety fallback.
             pose = self.lookup_robot_pose(timeout_sec=0.05, quiet=True)
             c1cam = self._lookup_tag_cam('charging_dock_tag_1')
             odom = self._lookup_odom_xy()
@@ -991,8 +968,7 @@ class DockTrigger(Node):
                     f'   docked: depth {depth:.3f}m ≤ {self.docking_distance:.2f}m')
                 return True
 
-            # Travel-safety bound only when a pose is available (FAR always has
-            # one; NEAR may not once the LiDAR is off).
+            # Travel-safety bound only when a pose is available.
             if pose is not None and math.hypot(pose[0] - x0, pose[1] - y0) > max_travel:
                 self._publish_cmd_vel(0.0, 0.0)
                 self.get_logger().error('   exceeded travel safety')
@@ -1000,37 +976,28 @@ class DockTrigger(Node):
 
             freeze = float(self.get_parameter('freeze_axis_distance').value)
             use_cam = bool(self.get_parameter('use_camera_frame_normal').value)
-            # Live-read the pure-pursuit gains + forward speed so they can be tuned
-            # with `ros2 param set /dock_trigger …` during a run. A LARGER lookahead
-            # and a HIGHER drive_speed both make the correction a gentler curve: with
-            # the 0.15 rad/s motor floor (min_turn_omega), turn radius = v/omega, so
-            # a slow v forces a tight turn that swings the camera off the bundle.
+            # Live-read the pure-pursuit gain + lookahead + forward speed so they
+            # can be tuned with `ros2 param set /dock_trigger …` during a run.
             line_kp = float(self.get_parameter('line_yaw_kp').value)
             lookahead = float(self.get_parameter('line_lookahead_distance').value)
             drive_speed = float(self.get_parameter('drive_speed').value)
-            est_base = (self._estimate_dock_base_once()
-                        if (use_cam and depth > freeze) else None)
+            est_base = self._estimate_dock_base_once() if use_cam else None
+
             if est_base is not None:
-                # FAR — ROBOT-FRAME dock-normal pure-pursuit. The 3-tag axis is
-                # re-derived in base_link (robot at the origin facing +x) every
+                # Tier 1 — ROBOT-FRAME dock-normal pure-pursuit (2+ tags). The axis
+                # is re-derived in base_link (robot at the origin facing +x) every
                 # loop, so it NEVER reads the wobbly map (AMCL relocalisation
                 # jumps) or odometry drift. Pure-pursuit onto the normal corrects
                 # BOTH the lateral offset from the dock axis AND the approach
-                # heading (perpendicular to the dock face) — the centre-tag
-                # bearing alone only corrected heading, which is why the robot
-                # arrived off-axis. This is the alignment-robust leg.
+                # heading (perpendicular to the dock face).
                 bcx, bcy, byaw = est_base
                 # robot is at (0, 0, 0) in base_link: rx = ry = ryaw = 0.
                 lateral = bcx * math.sin(byaw) - bcy * math.cos(byaw)
                 # Temporal EMA on the normal (byaw) + lateral, because WHILE MOVING
                 # a single frame jitters (vibration, blur, changing view angle).
-                # Reuse the SAME depth-weighted weight as the map-frame axis filter:
-                # the weight GROWS as the robot advances (∝ predock_distance/depth,
-                # capped 0.6), so the nearer, more accurate frames dominate the far
-                # early ones. We do NOT need a separate 'stop when too close' rule:
-                # below freeze_axis_distance the FAR pursuit already hands over to
-                # NEAR (outer tags leave the FOV, the estimate degrades). A frame
-                # jumping > axis_spike_reject from the filtered value is dropped.
+                # Weight GROWS as the robot advances (∝ predock_distance/depth,
+                # capped 0.6), so nearer, more accurate frames dominate the far
+                # early ones. A frame jumping > axis_spike_reject is dropped.
                 a_n = min(0.6, self.axis_filter_alpha
                           * (self.predock_distance / max(depth, 0.4)))
                 spike = float(self.get_parameter('axis_spike_reject').value)
@@ -1044,13 +1011,20 @@ class DockTrigger(Node):
                 desired_yaw = normalize_angle(
                     bnorm_filt - math.atan2(blat_filt, lookahead))
                 omega = line_kp * desired_yaw
-                self._publish_base_link_normal_marker(bnorm_filt, blat_filt, 'FAR-cam avg')
+                lost_frames = 0
+                # Keep the carried snapshot fresh for whenever tier 1 drops out
+                # (outer tags leave the FOV) — always the LATEST good axis, not a
+                # one-time freeze, so tier 2 picks up from the best data available.
+                carried_norm = bnorm_filt
+                carried_odom_yaw = self._lookup_odom_yaw()
+                self._publish_base_link_normal_marker(bnorm_filt, blat_filt, 'axis (2+ tags)')
             elif (not use_cam) and pose is not None and depth > freeze:
                 rx, ry, ryaw = pose
-                # LEGACY map-frame FAR leg (use_camera_frame_normal:=false): the
+                # LEGACY map-frame leg (use_camera_frame_normal:=false): the
                 # map-frame 3-tag axis is the noisy link (marginal id2, 52 cm
                 # baseline) and drifts with AMCL, so out here it just gets the
-                # robot roughly onto the perpendicular line.
+                # robot roughly onto the perpendicular line. Unused on the real
+                # robot (use_camera_frame_normal:=true) — kept for the sim path.
                 est = self._estimate_dock_once()
                 if est is not None:
                     ecx, ecy, eyaw = est
@@ -1069,122 +1043,30 @@ class DockTrigger(Node):
                     normal_yaw - math.atan2(lateral, lookahead))
                 yaw_err = normalize_angle(desired_yaw - ryaw)
                 omega = line_kp * yaw_err
+                lost_frames = 0
+            elif c1cam is not None and c1cam[2] > 0.0:
+                # Tier 2 — only the centre tag visible (outer tags out of FOV,
+                # too close). No fresh axis estimate possible from one point, so
+                # steer with the LAST good axis (carried_norm), corrected for
+                # however much the robot has turned since via odometry — same
+                # pure-pursuit law and gain as tier 1, no separate correction pass.
+                ref_yaw = 0.0
+                if carried_norm is not None and carried_odom_yaw is not None:
+                    odom_yaw_now = self._lookup_odom_yaw()
+                    if odom_yaw_now is not None:
+                        ref_yaw = normalize_angle(
+                            carried_norm - (odom_yaw_now - carried_odom_yaw))
+                lateral = c1cam[0]   # metric lateral offset (m) — solvePnP translation
+                desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral, lookahead))
+                omega = line_kp * desired_yaw
+                lost_frames = 0
+                self._publish_base_link_normal_marker(ref_yaw, lateral, 'centre-only carried')
             else:
-                # NEAR (dominant): trust the CAMERA. PD visual corrector on the
-                # image-frame bearing to the centre tag — P aims at the tag
-                # (this also cancels lateral offset: an off-centre robot sees the
-                # tag off-centre), D damps so a lively kp does not zig-zag. The
-                # noisy map-frame line is dropped here on purpose.
-                if not frozen and depth <= freeze:
-                    frozen = True
-                    # Snapshot the FAR-derived dock normal (robot-frame, from the wide
-                    # 2-outer-tag baseline) + the odom yaw at this exact instant. NEAR only
-                    # sees the centre tag (translation, not a trustworthy orientation), so
-                    # without this the NEAR steering law has no reference for the DOCK'S
-                    # true perpendicular — it only nulls the camera-frame lateral offset,
-                    # which converges the robot onto the line but does not constrain final
-                    # heading (a robot can keep the tag centred while arriving at an angle,
-                    # confirmed 2026-07-07: "sur la normale mais pas la bonne orientation").
-                    # Carrying bnorm_filt forward + correcting it by the odom yaw delta
-                    # (wheel+IMU EKF, LiDAR-independent) lets NEAR keep aiming at the dock's
-                    # actual normal instead of just "wherever the tag currently is".
-                    bnorm_at_freeze = bnorm_filt
-                    odom_yaw_at_freeze = self._lookup_odom_yaw()
-                    # Optionally cut the LiDAR at the FAR->NEAR hand-over. DISABLED
-                    # by default (stop_lidar_in_approach): on this unit stopping
-                    # the motor kills the AprilTag detection within ~1 s, so the
-                    # LiDAR stays on through the dock.
-                    if self.stop_lidar_in_approach:
-                        self._set_lidar_async(False)
-                    self.get_logger().info(
-                        f'   depth {depth:.2f}m ≤ {freeze:.2f}m — visual corrector '
-                        f'(PD on tag-1 lateral offset, fixed lookahead'
-                        + (', dock-normal carried via odometry'
-                           if bnorm_at_freeze is not None and odom_yaw_at_freeze is not None
-                           else ', NO frozen normal — falling back to point-at-tag') + ')'
-                        + ('; LiDAR off' if self.stop_lidar_in_approach else ''))
-                if c1cam is not None and c1cam[2] > 0.0:
-                    lost_frames = 0
-                    raw_angle = math.atan2(c1cam[0], c1cam[2])
-                    lateral_raw = c1cam[0]   # metric lateral offset (m) — solvePnP translation,
-                                              # already in metres, not a normalised image coord.
-                    kp = float(self.get_parameter('visual_servo_kp').value)
-                    kd = float(self.get_parameter('visual_servo_kd').value)
-                    a = float(self.get_parameter('visual_servo_filter_alpha').value)
-                    lookahead = float(self.get_parameter('visual_servo_lookahead').value)
-                    now_t = time.time()
-                    # Reference heading = the dock's true normal, carried forward from the
-                    # FAR->NEAR freeze and corrected for however much the robot has turned
-                    # since (odom yaw delta, LiDAR-independent). Falls back to 0 ("just point
-                    # at the tag", the old behaviour) if FAR never established a normal or
-                    # odom is briefly unavailable — never blocks the approach on this.
-                    ref_yaw = 0.0
-                    if bnorm_at_freeze is not None and odom_yaw_at_freeze is not None:
-                        odom_yaw_now = self._lookup_odom_yaw()
-                        if odom_yaw_now is not None:
-                            ref_yaw = normalize_angle(
-                                bnorm_at_freeze - (odom_yaw_now - odom_yaw_at_freeze))
-                    if filtered_angle is None:
-                        filtered_angle = raw_angle
-                        lateral_filt = lateral_raw
-                        desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral_filt, lookahead))
-                        d_desired = 0.0
-                        last_valid_t = now_t
-                    elif abs(raw_angle - filtered_angle) > self.visual_servo_max_step:
-                        # solvePnP flicker — reject, coast on the last good desired_yaw.
-                        # last_valid_t NOT refreshed: lateral_filt didn't move, so the
-                        # next accepted frame's dt correctly spans back to the last real
-                        # update, not this rejected one.
-                        desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral_filt, lookahead))
-                        d_desired = 0.0
-                    else:
-                        prev_desired_yaw = normalize_angle(
-                            ref_yaw - math.atan2(lateral_filt, lookahead))
-                        filtered_angle = a * raw_angle + (1.0 - a) * filtered_angle
-                        lateral_filt = a * lateral_raw + (1.0 - a) * lateral_filt
-                        # desired_yaw = ref_yaw - atan2(lateral, FIXED lookahead): aim at the
-                        # dock's actual normal (ref_yaw), pure-pursuit-corrected for the
-                        # residual lateral offset — mirrors FAR's formula exactly, just with a
-                        # frozen+odom-corrected normal instead of a continuously re-measured
-                        # one (NEAR only has the centre tag, translation only). A fixed
-                        # lookahead (not the shrinking depth) avoids the old gain blow-up
-                        # (2026-07-07 oscillation audit).
-                        desired_yaw = normalize_angle(ref_yaw - math.atan2(lateral_filt, lookahead))
-                        # Real elapsed time since the last update, NOT the nominal loop period —
-                        # see the D-term dt fix above; same gap-handling logic, now applied to
-                        # desired_yaw instead of the raw bearing.
-                        dt = now_t - last_valid_t if last_valid_t is not None else period
-                        if dt <= 0.0 or dt > 2.5 * period:
-                            d_desired = 0.0
-                        else:
-                            d_desired = (desired_yaw - prev_desired_yaw) / dt
-                        last_valid_t = now_t
-                    self._publish_base_link_normal_marker(ref_yaw, lateral_filt, 'NEAR carried')
-                    # Hysteresis deadband: drive straight while aligned, only
-                    # commit a correction past the outer band, release at the
-                    # inner band. Stops the per-frame left-right hunting; the
-                    # stiction floor below still makes an engaged turn execute.
-                    db = float(self.get_parameter('visual_align_deadband').value)
-                    mag = abs(desired_yaw)
-                    if mag > db:
-                        correcting = True
-                    elif mag < 0.4 * db:
-                        correcting = False
-                    omega = (kp * desired_yaw + kd * d_desired) if correcting else 0.0
-                else:
-                    # Tag 1 momentarily lost. We were tracking it (bearing was
-                    # small), so COAST STRAIGHT through brief dropouts (IR
-                    # speckle / motion blur) instead of stutter-stopping — the
-                    # stop-go is what wrecked the forward tracking. Straight =
-                    # toward where the aligned tag was (tag 1), never sideways
-                    # into an outer tag. Abort only if it stays lost too long.
-                    lost_frames += 1
-                    if lost_frames > self.visual_lost_max_frames:
-                        self._publish_cmd_vel(0.0, 0.0)
-                        self.get_logger().error(
-                            '   tag 1 lost too long in final approach — aborting')
-                        return False
-                    omega = 0.0   # fall through to the normal v taper + publish
+                # Tier 3 — nothing visible at all: go BLIND. No steering attempt,
+                # just keep advancing straight; depth is dead-reckoned from
+                # odometry above, so 'docked' still triggers correctly.
+                lost_frames += 1
+                omega = 0.0
 
             omega = max(-self.drive_yaw_max_omega,
                         min(self.drive_yaw_max_omega, omega))
@@ -1203,17 +1085,18 @@ class DockTrigger(Node):
                 # lowest clean speed. The old 0.03 floor sat in the judder band.
                 v = max(0.05, drive_speed * depth / taper)
 
-            # DEBUG (throttled ~2 Hz): which regime is actually driving Phase 5.
+            # DEBUG (throttled ~2 Hz): which tier is actually driving the approach.
             now_dbg = time.time()
             if now_dbg - getattr(self, '_p5_dbg', 0.0) > 0.5:
                 self._p5_dbg = now_dbg
-                branch = ('FAR-cam' if est_base is not None
-                          else ('FAR-map' if (not use_cam and pose is not None
-                                              and depth > freeze) else 'NEAR'))
+                tier = ('T1-axis' if est_base is not None
+                        else ('T-legacy-map' if (not use_cam and pose is not None
+                                                 and depth > freeze)
+                              else ('T2-centre' if c1cam is not None else 'T3-BLIND')))
                 norm_s = (f'{math.degrees(bnorm_filt):+.1f}'
                           if bnorm_filt is not None else '  n/a')
                 self.get_logger().info(
-                    f'   [P5] depth={depth:.2f} {branch} norm={norm_s}° '
+                    f'   [P5] depth={depth:.2f} {tier} norm={norm_s}° '
                     f'omega={omega:+.2f} v={v:.2f} '
                     f'c1={"Y" if (c1cam is not None) else "n"} '
                     f'base={"Y" if (est_base is not None) else "n"} lost={lost_frames}')

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -912,6 +912,7 @@ class DockTrigger(Node):
         n = 1
         frozen = False
         filtered_angle = None
+        last_valid_t = None     # wall-clock time filtered_angle was last actually updated
         bnorm_filt = None      # EMA of the ROBOT-frame dock normal (byaw), Phase-5 FAR
         blat_filt = None       # EMA of the lateral offset from the dock axis
         lost_frames = 0
@@ -1059,15 +1060,34 @@ class DockTrigger(Node):
                     kp = float(self.get_parameter('visual_servo_kp').value)
                     kd = float(self.get_parameter('visual_servo_kd').value)
                     a = float(self.get_parameter('visual_servo_filter_alpha').value)
+                    now_t = time.time()
                     if filtered_angle is None:
                         filtered_angle = raw_angle
                         d_angle = 0.0
+                        last_valid_t = now_t
                     elif abs(raw_angle - filtered_angle) > self.visual_servo_max_step:
                         d_angle = 0.0   # solvePnP flicker — reject, coast on last
+                        # last_valid_t NOT refreshed: filtered_angle didn't move, so the
+                        # next accepted frame's dt correctly spans back to the last real
+                        # update, not this rejected one.
                     else:
                         prev_angle = filtered_angle
                         filtered_angle = a * raw_angle + (1.0 - a) * filtered_angle
-                        d_angle = (filtered_angle - prev_angle) / period
+                        # Real elapsed time since filtered_angle last moved, NOT the nominal
+                        # loop period. Tag 1 flickers near contact (measured: 25% of frames
+                        # see 0 tags right before dock) — while lost, filtered_angle/prev_angle
+                        # sit frozen for several loop iterations, so dividing by the fixed
+                        # `period` on reacquisition inflated d_angle by however many periods
+                        # were skipped, injecting a spurious kd-scaled kick into omega right
+                        # after every reacquisition (2026-07-07 oscillation audit). A gap this
+                        # long (> 2.5 periods, ~125ms @ 20Hz) is reacquisition noise, not a
+                        # trustworthy rate — re-seed without a derivative kick instead.
+                        dt = now_t - last_valid_t if last_valid_t is not None else period
+                        if dt <= 0.0 or dt > 2.5 * period:
+                            d_angle = 0.0
+                        else:
+                            d_angle = (filtered_angle - prev_angle) / dt
+                        last_valid_t = now_t
                     # Hysteresis deadband: drive straight while aligned, only
                     # commit a correction past the outer band, release at the
                     # inner band. Stops the per-frame left-right hunting; the

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -880,7 +880,6 @@ class DockTrigger(Node):
         self._pub_status('docking')
         self._docking_active = True   # timer draws the normal from Phase 2/3 on
         self._pause_amcl()          # freeze map->odom: no relocalisation jumps during the maneuver
-        self._pause_collision_monitor()   # it fights /cmd_vel and stalls the approach ~15 cm out
         try:
             self.run_docking_sequence()
         except Exception as e:
@@ -961,6 +960,14 @@ class DockTrigger(Node):
             return
         self._publish_cmd_vel(0.0, 0.0)
         time.sleep(self.staging_hold_seconds)
+
+        # Nav2 (Phase 1) is DONE. Deactivate the collision_monitor only NOW: from
+        # here dock_trigger drives /cmd_vel directly, and an active monitor would
+        # fight it near the dock (both publish /cmd_vel) → stall ~15 cm out. It MUST
+        # stay active through Phase 1 above, or Nav2's controller→smoother→monitor→
+        # /cmd_vel chain is broken and the robot never reaches staging. Re-activated
+        # in _run_and_release's finally (any outcome).
+        self._pause_collision_monitor()
 
         # AprilTag pipeline ON now — it stayed idle during the Nav2 drive to the
         # staging zone (CPU left free for the planner). Instant: apriltag_node is

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -754,6 +754,12 @@ class DockTrigger(Node):
                     self.unified_odom_line = bool(p.value)
                     self.get_logger().info(
                         f'unified_odom_line -> {self.unified_odom_line} (live)')
+                elif p.name == 'obstacle_check_enabled':
+                    # false = ignore the forward obstacle guard (the dock itself
+                    # trips it at 0.6 m). Live so you can toggle it during a dock.
+                    self.obstacle_check_enabled = bool(p.value)
+                    self.get_logger().info(
+                        f'obstacle_check_enabled -> {self.obstacle_check_enabled} (live)')
             except (TypeError, ValueError):
                 return SetParametersResult(
                     successful=False, reason=f'bad value for {p.name}')

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -1847,8 +1847,16 @@ class DockTrigger(Node):
                 centred_count = 0
                 one = self._any_tag_cam()
                 if one is not None and one[2] > 0.05:
-                    # One tag visible — steer toward it to reveal the others.
+                    # One tag visible but NOT all — steer toward it to reveal the
+                    # others. FLOOR the turn: the proportional omega collapses
+                    # below the stiction floor as the tag nears image centre, so
+                    # the robot used to freeze facing a single tag and never
+                    # revealed the rest ("il ne tourne plus"). Keep it turning at
+                    # least scan speed until require_all succeeds above.
                     omega = -self.scan_centring_kp * math.atan2(one[0], one[2])
+                    if abs(omega) < self.min_turn_omega:
+                        omega = math.copysign(self.scan_rotation_speed,
+                                              omega if omega != 0.0 else 1.0)
                     omega = max(-self.scan_rotation_speed,
                                 min(self.scan_rotation_speed, omega))
                     self._publish_cmd_vel(0.0, omega)

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -167,7 +167,22 @@ class DockTrigger(Node):
         # Image-frame visual servo (camera-frame closed-loop on the centre
         # tag) used by the Phase 5 NEAR regime once the axis is frozen.
         #
-        #     omega = -visual_servo_kp · atan2(X_optical, Z_optical)
+        #     desired_yaw = -atan2(lateral, visual_servo_lookahead)
+        #     omega       = visual_servo_kp · desired_yaw + visual_servo_kd · d(desired_yaw)/dt
+        #
+        # `lateral` = c1cam[0], the tag's metric X translation in
+        # camera_optical_frame (solvePnP, already in metres — NOT a
+        # normalised image coordinate). Using a FIXED lookahead (like FAR's
+        # line_lookahead_distance) instead of the raw bearing atan2(X, Z)
+        # matters: atan2(X, Z) grows mechanically as depth Z shrinks for a
+        # CONSTANT physical lateral offset, so the old bearing-only P-term
+        # intensified purely from getting closer — not from any real
+        # drift — producing the worst corrections right at the end of the
+        # approach (2026-07-07 oscillation audit). Defaulted equal to
+        # freeze_axis_distance so desired_yaw is continuous across the
+        # FAR→NEAR hand-over (depth ≈ freeze_axis_distance right at the
+        # switch, so atan2(lateral, lookahead) ≈ atan2(lateral, depth) at
+        # that instant — no command jump).
         #
         # Map-frame solvePnP carries a systematic bias in the near field
         # (corners hugging the bottom of the FOV), but the image-frame
@@ -176,6 +191,7 @@ class DockTrigger(Node):
         # alpha rejects single-frame solvePnP spikes (alpha = 0.2 →
         # time constant ≈ 5 frames; alpha = 1.0 disables filtering).
         self.declare_parameter('visual_servo_kp', 1.0)            # rad/s per rad
+        self.declare_parameter('visual_servo_lookahead', 0.70)    # m — see rationale above
         self.declare_parameter('visual_servo_filter_alpha', 0.2)
         # PD + robustness terms for the visual corrector (Phase 5 NEAR). kd
         # damps the bearing so a lively kp does not zig-zag; max_step rejects
@@ -911,7 +927,11 @@ class DockTrigger(Node):
         asin, acos = math.sin(normal_yaw), math.cos(normal_yaw)
         n = 1
         frozen = False
-        filtered_angle = None
+        filtered_angle = None    # EMA of raw bearing atan2(X,Z) — kept ONLY as the
+                                  # frame-trustworthiness gate (visual_servo_max_step), not
+                                  # fed into the steering law (see lateral_filt below).
+        lateral_filt = None      # EMA of the metric lateral offset (c1cam[0], m) — the
+                                  # actual NEAR steering signal (depth-independent).
         last_valid_t = None     # wall-clock time filtered_angle was last actually updated
         bnorm_filt = None      # EMA of the ROBOT-frame dock normal (byaw), Phase-5 FAR
         blat_filt = None       # EMA of the lateral offset from the dock axis
@@ -1052,53 +1072,62 @@ class DockTrigger(Node):
                         self._set_lidar_async(False)
                     self.get_logger().info(
                         f'   depth {depth:.2f}m ≤ {freeze:.2f}m — visual corrector '
-                        f'(PD on tag-1 bearing)'
+                        f'(PD on tag-1 lateral offset, fixed lookahead)'
                         + ('; LiDAR off' if self.stop_lidar_in_approach else ''))
                 if c1cam is not None and c1cam[2] > 0.0:
                     lost_frames = 0
                     raw_angle = math.atan2(c1cam[0], c1cam[2])
+                    lateral_raw = c1cam[0]   # metric lateral offset (m) — solvePnP translation,
+                                              # already in metres, not a normalised image coord.
                     kp = float(self.get_parameter('visual_servo_kp').value)
                     kd = float(self.get_parameter('visual_servo_kd').value)
                     a = float(self.get_parameter('visual_servo_filter_alpha').value)
+                    lookahead = float(self.get_parameter('visual_servo_lookahead').value)
                     now_t = time.time()
                     if filtered_angle is None:
                         filtered_angle = raw_angle
-                        d_angle = 0.0
+                        lateral_filt = lateral_raw
+                        desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        d_desired = 0.0
                         last_valid_t = now_t
                     elif abs(raw_angle - filtered_angle) > self.visual_servo_max_step:
-                        d_angle = 0.0   # solvePnP flicker — reject, coast on last
-                        # last_valid_t NOT refreshed: filtered_angle didn't move, so the
+                        # solvePnP flicker — reject, coast on the last good desired_yaw.
+                        # last_valid_t NOT refreshed: lateral_filt didn't move, so the
                         # next accepted frame's dt correctly spans back to the last real
                         # update, not this rejected one.
+                        desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        d_desired = 0.0
                     else:
-                        prev_angle = filtered_angle
+                        prev_desired_yaw = -math.atan2(lateral_filt, lookahead)
                         filtered_angle = a * raw_angle + (1.0 - a) * filtered_angle
-                        # Real elapsed time since filtered_angle last moved, NOT the nominal
-                        # loop period. Tag 1 flickers near contact (measured: 25% of frames
-                        # see 0 tags right before dock) — while lost, filtered_angle/prev_angle
-                        # sit frozen for several loop iterations, so dividing by the fixed
-                        # `period` on reacquisition inflated d_angle by however many periods
-                        # were skipped, injecting a spurious kd-scaled kick into omega right
-                        # after every reacquisition (2026-07-07 oscillation audit). A gap this
-                        # long (> 2.5 periods, ~125ms @ 20Hz) is reacquisition noise, not a
-                        # trustworthy rate — re-seed without a derivative kick instead.
+                        lateral_filt = a * lateral_raw + (1.0 - a) * lateral_filt
+                        # desired_yaw = -atan2(lateral, FIXED lookahead), not the raw bearing
+                        # atan2(X, Z): Z (depth) shrinks through NEAR, so the raw bearing grows
+                        # mechanically for a CONSTANT physical lateral offset — the P-term used
+                        # to intensify purely from getting closer, worst right at the end
+                        # (2026-07-07 oscillation audit). A fixed lookahead (mirrors FAR's
+                        # line_lookahead_distance pure-pursuit) removes that depth dependence.
+                        desired_yaw = -math.atan2(lateral_filt, lookahead)
+                        # Real elapsed time since the last update, NOT the nominal loop period —
+                        # see the D-term dt fix above; same gap-handling logic, now applied to
+                        # desired_yaw instead of the raw bearing.
                         dt = now_t - last_valid_t if last_valid_t is not None else period
                         if dt <= 0.0 or dt > 2.5 * period:
-                            d_angle = 0.0
+                            d_desired = 0.0
                         else:
-                            d_angle = (filtered_angle - prev_angle) / dt
+                            d_desired = (desired_yaw - prev_desired_yaw) / dt
                         last_valid_t = now_t
                     # Hysteresis deadband: drive straight while aligned, only
                     # commit a correction past the outer band, release at the
                     # inner band. Stops the per-frame left-right hunting; the
                     # stiction floor below still makes an engaged turn execute.
                     db = float(self.get_parameter('visual_align_deadband').value)
-                    mag = abs(filtered_angle)
+                    mag = abs(desired_yaw)
                     if mag > db:
                         correcting = True
                     elif mag < 0.4 * db:
                         correcting = False
-                    omega = -(kp * filtered_angle + kd * d_angle) if correcting else 0.0
+                    omega = (kp * desired_yaw + kd * d_desired) if correcting else 0.0
                 else:
                     # Tag 1 momentarily lost. We were tracking it (bearing was
                     # small), so COAST STRAIGHT through brief dropouts (IR

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -49,6 +49,7 @@ from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
 from std_msgs.msg import Bool, String
+from std_srvs.srv import SetBool, Empty
 from geometry_msgs.msg import Point, PoseStamped, Twist
 from sensor_msgs.msg import LaserScan
 from nav2_msgs.action import (
@@ -113,10 +114,12 @@ class DockTrigger(Node):
         self.declare_parameter('undock_reverse_distance', 1.5)   # m straight back
         self.declare_parameter('undock_reverse_speed', 0.10)     # m/s (magnitude)
 
-        # Dock pose in map frame (must match nav2_sim_full.yaml docks/home_dock)
-        self.declare_parameter('dock_pose_x', 0.0)
-        self.declare_parameter('dock_pose_y', 4.9)
-        self.declare_parameter('dock_pose_yaw', 1.5707)
+        # Dock pose in map frame. Defaults ALIGNED with config/dock_trigger.yaml (sim dock at the
+        # +X wall) so a stray standalone launch can't drive to a contradictory hard-coded pose.
+        # The REAL dock pose MUST be measured in your real map and set in dock_trigger.yaml (B2).
+        self.declare_parameter('dock_pose_x', 4.899)
+        self.declare_parameter('dock_pose_y', 0.0)
+        self.declare_parameter('dock_pose_yaw', 0.0)
 
         # Staging
         self.declare_parameter('staging_distance', 1.5)        # m in front of dock
@@ -127,6 +130,13 @@ class DockTrigger(Node):
         self.declare_parameter('drive_speed', 0.10)            # m/s forward
         self.declare_parameter('drive_yaw_kp', 1.5)            # angular P gain during drive
         self.declare_parameter('drive_yaw_max_omega', 0.5)     # rad/s clamp on correction
+        # Rotation stiction floor. Measured on this robot
+        # (scripts/min_velocity_sweep.py, 2026-07-02): below ~0.15 rad/s the
+        # wheels stick-slip and an angular correction never executes. Snap
+        # corrections in (turn_deadband, min_turn_omega) up to the floor, and
+        # command 0 inside the deadband to avoid hunting around zero.
+        self.declare_parameter('min_turn_omega', 0.15)         # rad/s rotation floor
+        self.declare_parameter('turn_deadband', 0.04)          # rad/s: below -> omega 0
 
         # Line-tracking advance — pure-pursuit-style controller. Each iteration
         # we compute a desired heading
@@ -167,6 +177,33 @@ class DockTrigger(Node):
         # time constant ≈ 5 frames; alpha = 1.0 disables filtering).
         self.declare_parameter('visual_servo_kp', 1.0)            # rad/s per rad
         self.declare_parameter('visual_servo_filter_alpha', 0.2)
+        # PD + robustness terms for the visual corrector (Phase 5 NEAR). kd
+        # damps the bearing so a lively kp does not zig-zag; max_step rejects
+        # single-frame solvePnP bearing jumps; lost_max_frames bounds how long
+        # tag 1 may stay undetected before the approach aborts (rather than
+        # driving blind).
+        self.declare_parameter('visual_servo_kd', 0.2)           # rad/s per rad/s — damping
+        self.declare_parameter('visual_servo_max_step', 0.35)    # rad — reject bearing flicker
+        self.declare_parameter('visual_lost_max_frames', 15)     # frames lost before abort
+        # Alignment deadband (hysteresis) for the visual corrector: drive
+        # STRAIGHT while the bearing is within the inner band, only commit a
+        # correction once it exceeds the outer band, release again at the inner
+        # band. This — not a per-frame stiction-floor snap — is what stops the
+        # left-right hunting: corrections become gentle engaged arcs, not a
+        # 20 Hz pulse train. Inner band = 0.4 x outer.
+        self.declare_parameter('visual_align_deadband', 0.10)    # rad (~5.7 deg) outer band
+        # Sigma-delta PWM of the yaw command so a SUB-FLOOR correction executes as
+        # a gentle pulsed turn instead of snapping to the ±min_turn_omega stiction
+        # floor (a hard snap gives the ±0.15 rad/s left-right limit cycle around the
+        # line). True: below the floor emit ±min_turn_omega pulses whose TIME AVERAGE
+        # equals the desired rate → effective gentle turn; above it pass through.
+        # False: legacy hard floor. Live-tunable.
+        self.declare_parameter('omega_pwm', True)
+        # Stop the LiDAR during the NEAR visual approach (its IR dot can drop tag
+        # detections). OFF by default: on this unit stopping the motor ALSO kills
+        # the AprilTag detection within ~1 s (rplidar + apriltag share a component
+        # container — the motor stop disrupts it), so we keep the LiDAR on.
+        self.declare_parameter('stop_lidar_in_approach', False)
 
         # Initial tag-search scan. After Nav2 reaches the staging zone the
         # tag may not be in the camera frame (Nav2 goal yaw tolerance plus
@@ -186,10 +223,27 @@ class DockTrigger(Node):
         self.declare_parameter('spin_kp', 2.0)
         self.declare_parameter('spin_max_omega', 0.6)
         self.declare_parameter('spin_yaw_tolerance', 0.02)     # ~1.1°
+        # Spin-in-place floor: a P-controlled spin near its target commands a tiny
+        # omega that falls below the STATIC-friction limit → the robot judders in
+        # place without turning ('does not rotate on itself'). Starting a spin from
+        # rest needs more than the ~0.15 rad/s continuous floor, so snap any small
+        # non-zero spin command up to this. Above spin_yaw_tolerance it always turns.
+        self.declare_parameter('spin_min_omega', 0.25)         # rad/s spin-from-rest floor
 
         # Tag detection
         self.declare_parameter('detection_topic', '/detected_dock_pose')
         self.declare_parameter('detection_max_age', 1.5)       # s — drop stale msgs
+
+        # ── On-demand AprilTag image gate (real robot) ─────────────────────
+        # apriltag_node is CPU-heavy (~1.6 cores on the Pi) and only needed for
+        # the final dock approach. The gate (openamrobot_docking/apriltag_gate.py)
+        # (un)subscribes the camera feed to apriltag via this SetBool service, so
+        # apriltag idles at ~0% CPU during navigation and toggles instantly (it
+        # stays alive). We ENABLE it once at the staging zone and DISABLE it when
+        # the sequence ends. Disabled by default (sim has apriltag always-on and
+        # no gate service); docking_real.launch.py opts in with use_apriltag_gate.
+        self.declare_parameter('use_apriltag_gate', False)
+        self.declare_parameter('apriltag_gate_service', '/apriltag/set_enabled')
 
         # Temporal filtering of tag pose: collect N samples, average them
         self.declare_parameter('filter_num_samples', 20)
@@ -233,6 +287,21 @@ class DockTrigger(Node):
         # following the recent, better ones as the robot centres up. Higher =
         # more reactive (noisier), lower = smoother (slower).
         self.declare_parameter('axis_filter_alpha', 0.15)
+        # Compute the Phase-5 FAR dock centre + normal in the ROBOT frame
+        # (base_link, from the live camera TF) instead of the map frame. True =
+        # the final approach NEVER reads the wobbly map (AMCL relocalisation
+        # jumps) or odometry drift: the 3-tag axis is re-derived every loop
+        # relative to the robot, so pure-pursuit corrects BOTH the lateral offset
+        # from the dock normal AND the approach heading (perpendicular to the
+        # dock face). False = legacy map-frame line. See
+        # docs/AUDIT-2026-07-03-cpu-pipeline-optimization.md follow-up.
+        self.declare_parameter('use_camera_frame_normal', True)
+        # Spike-reject gate for the ROBOT-frame normal EMA (Phase-5 FAR): a frame
+        # whose normal jumps more than this from the filtered value is a bad
+        # detection → dropped, not averaged in. The EMA *weight* itself is NOT a new
+        # knob — it reuses the existing depth-weighted axis_filter_alpha (weight
+        # grows as the robot advances). Live-tunable.
+        self.declare_parameter('axis_spike_reject', 0.35)       # rad (~20°) outlier gate
 
         # ── Obstacle avoidance during drive phases ─────────────────────────
         # The sequencer publishes cmd_vel straight to the robot, bypassing
@@ -268,6 +337,11 @@ class DockTrigger(Node):
         # you must fall back to /scan — and then pick a value clearly
         # below the closest legitimate obstacle distance.
         self.declare_parameter('obstacle_min_range', 0.0)               # m — 0 = disabled
+        # Scan-frame angle that points to the robot's FORWARD. 0.0 in sim (lidar aligned with
+        # base_link). On THIS real robot the RPLIDAR is mounted rotated 180° (yaw=π), so scan
+        # angle 0 points BACKWARD — set this to 3.14159 in the real dock_trigger.yaml, otherwise
+        # the forward obstacle cone watches the rear and the robot drives in blind.
+        self.declare_parameter('obstacle_scan_forward_angle', 0.0)      # rad (real robot: 3.14159)
 
         self.trigger_topic = self.get_parameter('trigger_topic').value
         self.undock_on_false = self.get_parameter('undock_on_false').value
@@ -286,10 +360,15 @@ class DockTrigger(Node):
         self.drive_speed = float(self.get_parameter('drive_speed').value)
         self.drive_yaw_kp = float(self.get_parameter('drive_yaw_kp').value)
         self.drive_yaw_max_omega = float(self.get_parameter('drive_yaw_max_omega').value)
+        self.min_turn_omega = float(self.get_parameter('min_turn_omega').value)
+        self.turn_deadband = float(self.get_parameter('turn_deadband').value)
         self.line_yaw_kp = float(self.get_parameter('line_yaw_kp').value)
         self.line_lookahead_distance = float(self.get_parameter('line_lookahead_distance').value)
         self.visual_servo_kp = float(self.get_parameter('visual_servo_kp').value)
         self.visual_servo_filter_alpha = float(self.get_parameter('visual_servo_filter_alpha').value)
+        self.visual_servo_max_step = float(self.get_parameter('visual_servo_max_step').value)
+        self.visual_lost_max_frames = int(self.get_parameter('visual_lost_max_frames').value)
+        self.stop_lidar_in_approach = bool(self.get_parameter('stop_lidar_in_approach').value)
         self.scan_rotation_speed = float(self.get_parameter('scan_rotation_speed').value)
         self.scan_consecutive_target = int(self.get_parameter('scan_consecutive_target').value)
         self.scan_centring_tolerance = float(self.get_parameter('scan_centring_tolerance').value)
@@ -299,8 +378,11 @@ class DockTrigger(Node):
         self.spin_kp = float(self.get_parameter('spin_kp').value)
         self.spin_max_omega = float(self.get_parameter('spin_max_omega').value)
         self.spin_yaw_tolerance = float(self.get_parameter('spin_yaw_tolerance').value)
+        self.spin_min_omega = float(self.get_parameter('spin_min_omega').value)
         self.detection_topic = self.get_parameter('detection_topic').value
         self.detection_max_age = float(self.get_parameter('detection_max_age').value)
+        self.use_apriltag_gate = bool(self.get_parameter('use_apriltag_gate').value)
+        self.apriltag_gate_service = self.get_parameter('apriltag_gate_service').value
         self.filter_num_samples = int(self.get_parameter('filter_num_samples').value)
         self.filter_max_collect_time = float(self.get_parameter('filter_max_collect_time').value)
         self.publish_debug_markers = bool(self.get_parameter('publish_debug_markers').value)
@@ -327,6 +409,8 @@ class DockTrigger(Node):
         self.obstacle_wait_timeout = float(self.get_parameter('obstacle_wait_timeout').value)
         self.obstacle_check_period = float(self.get_parameter('obstacle_check_period').value)
         self.obstacle_min_range = float(self.get_parameter('obstacle_min_range').value)
+        self.obstacle_scan_forward_angle = float(
+            self.get_parameter('obstacle_scan_forward_angle').value)
 
         # ── Multi-threaded callback group so the long-running sequence can
         #    run while subscriptions and TF still get processed. ────────────
@@ -337,6 +421,17 @@ class DockTrigger(Node):
                                        callback_group=self.cb_group)
         self.undock_client = ActionClient(self, UndockRobot, 'undock_robot',
                                           callback_group=self.cb_group)
+
+        # ── On-demand AprilTag gate client (real robot; see _set_apriltag) ──
+        self._apriltag_gate_cli = self.create_client(
+            SetBool, self.apriltag_gate_service, callback_group=self.cb_group)
+
+        # ── LiDAR motor clients: stop it during the camera phases so its IR
+        #    laser dot doesn't sweep across the tags (see _set_lidar). ────────
+        self._lidar_stop_cli = self.create_client(
+            Empty, '/stop_motor', callback_group=self.cb_group)
+        self._lidar_start_cli = self.create_client(
+            Empty, '/start_motor', callback_group=self.cb_group)
 
         # ── cmd_vel publisher (closed-loop drive phase) ────────────────────
         self.cmd_vel_pub = self.create_publisher(Twist, self.cmd_vel_topic, 10)
@@ -371,6 +466,14 @@ class DockTrigger(Node):
         # ── Goal-pose gate publisher (forwards to Nav2 after undock) ────────
         self.goal_pose_pub = self.create_publisher(
             PoseStamped, self.goal_pose_forward_topic, 10)
+
+        # A6 guard: there must be exactly ONE forwarder on the Nav2 goal topic. If another node
+        # also publishes there (a leftover topic_tools goal relay, or an orphaned dock_trigger from
+        # an incomplete shutdown), every RViz "2D Goal Pose" is published TWICE -> Nav2 receives a
+        # duplicate goal. We can't kill the other node, but we warn loudly so the operator fixes it.
+        # Checked once a few seconds after startup (lets other nodes register first).
+        self._fwd_guard_timer = self.create_timer(
+            4.0, self._check_single_forwarder, callback_group=self.cb_group)
 
         # ── Debug marker publisher (perpendicular line + tag centre) ────────
         self.marker_pub = self.create_publisher(
@@ -419,6 +522,98 @@ class DockTrigger(Node):
         if not self.busy:
             self._pub_status('docked' if self.is_docked else 'idle')
 
+    def _check_single_forwarder(self) -> None:
+        """One-shot A6 guard: warn if more than one node publishes the Nav2 goal topic."""
+        self._fwd_guard_timer.cancel()  # run once only
+        topic = self.goal_pose_pub.topic_name
+        try:
+            n = self.count_publishers(topic)
+        except Exception:
+            return
+        if n > 1:
+            self.get_logger().error(
+                f'DOUBLE FORWARDER: {n} publishers on {topic} (expected 1 = this dock_trigger). '
+                'A leftover goal relay or an orphaned dock_trigger is running -> every goal is sent '
+                'twice. Stop the extra forwarder (only ONE of relay / dock_trigger may run).')
+        else:
+            self.get_logger().info(f'Goal forwarder OK: sole publisher on {topic}.')
+
+    def _set_apriltag(self, enabled: bool) -> None:
+        """Enable/disable the on-demand AprilTag image gate (real robot).
+
+        apriltag_node stays alive; the gate just (un)subscribes the camera feed,
+        so toggling is instant and apriltag burns ~0% CPU while disabled (during
+        navigation). No-op (with a warning) if the gate service is absent — e.g.
+        in simulation, where apriltag is always on and there is no gate.
+        """
+        if not self.use_apriltag_gate:
+            return
+        cli = self._apriltag_gate_cli
+        if not cli.wait_for_service(timeout_sec=1.0):
+            self.get_logger().warn(
+                f"AprilTag gate service '{self.apriltag_gate_service}' unavailable — "
+                f"leaving apriltag as-is (always-on?). "
+                f"Skipping {'enable' if enabled else 'disable'}.")
+            return
+        req = SetBool.Request()
+        req.data = enabled
+        future = cli.call_async(req)
+        # Don't block the sequence on the response — the gate toggles within one
+        # frame regardless. A short wait just confirms the call was accepted (the
+        # MultiThreadedExecutor resolves the future on another thread).
+        t0 = time.time()
+        while not future.done() and time.time() - t0 < 1.0:
+            time.sleep(0.02)
+        self.get_logger().info(
+            f"AprilTag gate -> {'ENABLED' if enabled else 'disabled'}")
+
+    def _set_lidar(self, running: bool) -> None:
+        """Start/stop the RPLIDAR motor during the camera phases.
+
+        The LiDAR's IR laser sweeps a bright dot across the tags and drops
+        apriltag detections. The visual approach doesn't use the LiDAR
+        (obstacle guard off, we drive cmd_vel directly), so stop it at the
+        staging zone and restart it in the finally. Gated on use_apriltag_gate
+        (real robot); no-op (with a warning) if the motor service is absent.
+
+        Blocking (waits for the service) — used for the RESTART in the finally,
+        where a short wait is fine. The in-loop STOP uses _set_lidar_async so it
+        never stalls the drive. Re-enabled 2026-07-02: the LiDAR is cut only at
+        the FAR->NEAR hand-over (NEAR is camera-only), so localisation stays alive
+        through FAR and is always restarted in _run_and_release's finally.
+        """
+        if not self.use_apriltag_gate:
+            return
+        cli = self._lidar_start_cli if running else self._lidar_stop_cli
+        if not cli.wait_for_service(timeout_sec=1.0):
+            self.get_logger().warn(
+                "LiDAR motor service unavailable — leaving LiDAR as-is. "
+                f"Skipping {'start' if running else 'stop'}.")
+            return
+        future = cli.call_async(Empty.Request())
+        t0 = time.time()
+        while not future.done() and time.time() - t0 < 1.0:
+            time.sleep(0.02)
+        self.get_logger().info(
+            f"LiDAR motor -> {'STARTED' if running else 'stopped'}")
+
+    def _set_lidar_async(self, running: bool) -> None:
+        """Fire-and-forget LiDAR motor start/stop — safe to call from the control
+        loop: no wait_for_service, no future wait, so it never stalls the drive.
+        The request is transmitted by the spinning executor; we don't need the
+        reply."""
+        if not self.use_apriltag_gate:
+            return
+        cli = self._lidar_start_cli if running else self._lidar_stop_cli
+        if not cli.service_is_ready():
+            self.get_logger().warn(
+                f"LiDAR motor service not ready — skipping async "
+                f"{'start' if running else 'stop'}.")
+            return
+        cli.call_async(Empty.Request())
+        self.get_logger().info(
+            f"LiDAR motor -> {'START' if running else 'STOP'} (async)")
+
     def on_detection(self, msg: PoseStamped):
         self.detected_pose = msg
 
@@ -443,6 +638,9 @@ class DockTrigger(Node):
         except Exception as e:
             self.get_logger().error(f'Docking sequence error: {e}')
         finally:
+            self._set_apriltag(False)   # apriltag back to ~0% CPU
+            if self.stop_lidar_in_approach:
+                self._set_lidar(True)   # LiDAR back on (only if we stopped it)
             self._pub_status('docked' if self.is_docked else 'failed')
             self.busy = False
 
@@ -513,6 +711,12 @@ class DockTrigger(Node):
         self._publish_cmd_vel(0.0, 0.0)
         time.sleep(self.staging_hold_seconds)
 
+        # AprilTag pipeline ON now — it stayed idle during the Nav2 drive to the
+        # staging zone (CPU left free for the planner). Instant: apriltag_node is
+        # already up; the gate just starts forwarding frames. Disabled again in
+        # _run_and_release's finally, whatever the outcome.
+        self._set_apriltag(True)
+
         # See both tags and estimate the dock (centre + normal from baseline).
         if not self._search_for_tag():
             self.get_logger().error('   tags not detected during scan — aborting')
@@ -576,6 +780,10 @@ class DockTrigger(Node):
             self.get_logger().info('   normals agree — confirmed')
 
         # ── Phase 5: final visual approach (camera-only). ─────────────────
+        # The LiDAR is NOT stopped here: the FAR leg still uses the map-frame
+        # line (AMCL), so the LiDAR is cut later, exactly at the FAR->NEAR
+        # hand-over inside _final_visual_approach (async), and restarted in the
+        # _run_and_release finally.
         self.get_logger().info(
             f'── Phase 5: visual approach to {self.docking_distance:.2f}m (camera depth)')
         if not self._final_visual_approach(cx, cy, normal_yaw):
@@ -665,7 +873,7 @@ class DockTrigger(Node):
         # drive. This catches "someone is directly in front of the robot when
         # the trigger arrives" up front, before the drive loop starts.
         if not self._wait_for_path_clear(
-            0.0, self.obstacle_forward_distance,
+            self.obstacle_scan_forward_angle, self.obstacle_forward_distance,
             self.obstacle_wait_timeout, 'goto-point pre-check'
         ):
             return False
@@ -704,42 +912,111 @@ class DockTrigger(Node):
         n = 1
         frozen = False
         filtered_angle = None
+        bnorm_filt = None      # EMA of the ROBOT-frame dock normal (byaw), Phase-5 FAR
+        blat_filt = None       # EMA of the lateral offset from the dock axis
+        lost_frames = 0
+        correcting = False
+        last_cam_depth = None       # last camera depth to tag 1 (odom dead-reckoning)
+        last_odom = None            # odom xy captured with last_cam_depth
 
         pose0 = self.lookup_robot_pose()
         if pose0 is None:
             return False
         x0, y0, _ = pose0
         max_travel = math.hypot(cx - x0, cy - y0) + 0.5
+        last_depth = max(0.0, math.hypot(cx - x0, cy - y0) - camera_forward_offset)
 
         while time.time() < deadline:
-            pose = self.lookup_robot_pose()
-            if pose is None:
-                time.sleep(period)
-                continue
-            rx, ry, ryaw = pose
-
+            # Pose is OPTIONAL here (short timeout, quiet): once the LiDAR is cut
+            # at the FAR->NEAR hand-over the map→odom TF ages out, and blocking on
+            # it would stall the advance. NEAR runs on the camera alone; pose only
+            # serves FAR (LiDAR still on) and a fallback.
+            pose = self.lookup_robot_pose(timeout_sec=0.05, quiet=True)
             c1cam = self._lookup_tag_cam('charging_dock_tag_1')
+            odom = self._lookup_odom_xy()
+
             if c1cam is not None and c1cam[2] > 0.05:
-                depth = c1cam[2]
-            else:
-                depth = max(0.0, math.hypot(cx - rx, cy - ry)
+                depth = c1cam[2]                       # camera depth (LiDAR-independent)
+                if odom is not None:
+                    last_cam_depth, last_odom = depth, odom
+            elif last_cam_depth is not None and last_odom is not None and odom is not None:
+                # Tag not in view — dead-reckon depth from odometry (always live,
+                # LiDAR-independent). Lets the last blind centimetres still detect
+                # 'docked' with the LiDAR off.
+                travelled = math.hypot(odom[0] - last_odom[0], odom[1] - last_odom[1])
+                depth = max(0.0, last_cam_depth - travelled)
+            elif pose is not None:
+                depth = max(0.0, math.hypot(cx - pose[0], cy - pose[1])
                             - camera_forward_offset)
+            else:
+                depth = last_depth
+            last_depth = depth
+
             if depth <= self.docking_distance:
                 self._publish_cmd_vel(0.0, 0.0)
                 self.get_logger().info(
                     f'   docked: depth {depth:.3f}m ≤ {self.docking_distance:.2f}m')
                 return True
 
-            if math.hypot(rx - x0, ry - y0) > max_travel:
+            # Travel-safety bound only when a pose is available (FAR always has
+            # one; NEAR may not once the LiDAR is off).
+            if pose is not None and math.hypot(pose[0] - x0, pose[1] - y0) > max_travel:
                 self._publish_cmd_vel(0.0, 0.0)
                 self.get_logger().error('   exceeded travel safety')
                 return False
 
-            if depth > self.freeze_axis_distance:
-                # FAR: refine the axis with a proximity-weighted EMA. The EMA
-                # weight grows as the robot gets closer, so the samples taken
-                # while advancing (nearer = tags bigger in the image = more
-                # accurate) count MUCH more than the early far ones.
+            freeze = float(self.get_parameter('freeze_axis_distance').value)
+            use_cam = bool(self.get_parameter('use_camera_frame_normal').value)
+            # Live-read the pure-pursuit gains + forward speed so they can be tuned
+            # with `ros2 param set /dock_trigger …` during a run. A LARGER lookahead
+            # and a HIGHER drive_speed both make the correction a gentler curve: with
+            # the 0.15 rad/s motor floor (min_turn_omega), turn radius = v/omega, so
+            # a slow v forces a tight turn that swings the camera off the bundle.
+            line_kp = float(self.get_parameter('line_yaw_kp').value)
+            lookahead = float(self.get_parameter('line_lookahead_distance').value)
+            drive_speed = float(self.get_parameter('drive_speed').value)
+            est_base = (self._estimate_dock_base_once()
+                        if (use_cam and depth > freeze) else None)
+            if est_base is not None:
+                # FAR — ROBOT-FRAME dock-normal pure-pursuit. The 3-tag axis is
+                # re-derived in base_link (robot at the origin facing +x) every
+                # loop, so it NEVER reads the wobbly map (AMCL relocalisation
+                # jumps) or odometry drift. Pure-pursuit onto the normal corrects
+                # BOTH the lateral offset from the dock axis AND the approach
+                # heading (perpendicular to the dock face) — the centre-tag
+                # bearing alone only corrected heading, which is why the robot
+                # arrived off-axis. This is the alignment-robust leg.
+                bcx, bcy, byaw = est_base
+                # robot is at (0, 0, 0) in base_link: rx = ry = ryaw = 0.
+                lateral = bcx * math.sin(byaw) - bcy * math.cos(byaw)
+                # Temporal EMA on the normal (byaw) + lateral, because WHILE MOVING
+                # a single frame jitters (vibration, blur, changing view angle).
+                # Reuse the SAME depth-weighted weight as the map-frame axis filter:
+                # the weight GROWS as the robot advances (∝ predock_distance/depth,
+                # capped 0.6), so the nearer, more accurate frames dominate the far
+                # early ones. We do NOT need a separate 'stop when too close' rule:
+                # below freeze_axis_distance the FAR pursuit already hands over to
+                # NEAR (outer tags leave the FOV, the estimate degrades). A frame
+                # jumping > axis_spike_reject from the filtered value is dropped.
+                a_n = min(0.6, self.axis_filter_alpha
+                          * (self.predock_distance / max(depth, 0.4)))
+                spike = float(self.get_parameter('axis_spike_reject').value)
+                if bnorm_filt is None:
+                    bnorm_filt, blat_filt = byaw, lateral
+                elif abs(normalize_angle(byaw - bnorm_filt)) <= spike:
+                    bnorm_filt = normalize_angle(
+                        bnorm_filt + a_n * normalize_angle(byaw - bnorm_filt))
+                    blat_filt = (1.0 - a_n) * blat_filt + a_n * lateral
+                # else: spike — keep the last filtered normal this frame
+                desired_yaw = normalize_angle(
+                    bnorm_filt - math.atan2(blat_filt, lookahead))
+                omega = line_kp * desired_yaw
+            elif (not use_cam) and pose is not None and depth > freeze:
+                rx, ry, ryaw = pose
+                # LEGACY map-frame FAR leg (use_camera_frame_normal:=false): the
+                # map-frame 3-tag axis is the noisy link (marginal id2, 52 cm
+                # baseline) and drifts with AMCL, so out here it just gets the
+                # robot roughly onto the perpendicular line.
                 est = self._estimate_dock_once()
                 if est is not None:
                     ecx, ecy, eyaw = est
@@ -755,34 +1032,99 @@ class DockTrigger(Node):
                 lateral = (-(rx - cx) * math.sin(normal_yaw)
                            + (ry - cy) * math.cos(normal_yaw))
                 desired_yaw = normalize_angle(
-                    normal_yaw - math.atan2(lateral, self.line_lookahead_distance))
+                    normal_yaw - math.atan2(lateral, lookahead))
                 yaw_err = normalize_angle(desired_yaw - ryaw)
-                omega = self.line_yaw_kp * yaw_err
+                omega = line_kp * yaw_err
             else:
-                # NEAR: axis frozen, finish on the centre-tag visual corrector.
-                if not frozen:
+                # NEAR (dominant): trust the CAMERA. PD visual corrector on the
+                # image-frame bearing to the centre tag — P aims at the tag
+                # (this also cancels lateral offset: an off-centre robot sees the
+                # tag off-centre), D damps so a lively kp does not zig-zag. The
+                # noisy map-frame line is dropped here on purpose.
+                if not frozen and depth <= freeze:
                     frozen = True
+                    # Optionally cut the LiDAR at the FAR->NEAR hand-over. DISABLED
+                    # by default (stop_lidar_in_approach): on this unit stopping
+                    # the motor kills the AprilTag detection within ~1 s, so the
+                    # LiDAR stays on through the dock.
+                    if self.stop_lidar_in_approach:
+                        self._set_lidar_async(False)
                     self.get_logger().info(
-                        f'   depth {depth:.2f}m ≤ {self.freeze_axis_distance:.2f}m '
-                        f'— freezing axis ({n} samples), visual corrector')
+                        f'   depth {depth:.2f}m ≤ {freeze:.2f}m — visual corrector '
+                        f'(PD on tag-1 bearing)'
+                        + ('; LiDAR off' if self.stop_lidar_in_approach else ''))
                 if c1cam is not None and c1cam[2] > 0.0:
+                    lost_frames = 0
                     raw_angle = math.atan2(c1cam[0], c1cam[2])
+                    kp = float(self.get_parameter('visual_servo_kp').value)
+                    kd = float(self.get_parameter('visual_servo_kd').value)
+                    a = float(self.get_parameter('visual_servo_filter_alpha').value)
                     if filtered_angle is None:
                         filtered_angle = raw_angle
+                        d_angle = 0.0
+                    elif abs(raw_angle - filtered_angle) > self.visual_servo_max_step:
+                        d_angle = 0.0   # solvePnP flicker — reject, coast on last
                     else:
-                        a = self.visual_servo_filter_alpha
+                        prev_angle = filtered_angle
                         filtered_angle = a * raw_angle + (1.0 - a) * filtered_angle
-                    omega = -self.visual_servo_kp * filtered_angle
+                        d_angle = (filtered_angle - prev_angle) / period
+                    # Hysteresis deadband: drive straight while aligned, only
+                    # commit a correction past the outer band, release at the
+                    # inner band. Stops the per-frame left-right hunting; the
+                    # stiction floor below still makes an engaged turn execute.
+                    db = float(self.get_parameter('visual_align_deadband').value)
+                    mag = abs(filtered_angle)
+                    if mag > db:
+                        correcting = True
+                    elif mag < 0.4 * db:
+                        correcting = False
+                    omega = -(kp * filtered_angle + kd * d_angle) if correcting else 0.0
                 else:
-                    omega = 0.0   # tag out of view in the last cm — go straight
+                    # Tag 1 momentarily lost. We were tracking it (bearing was
+                    # small), so COAST STRAIGHT through brief dropouts (IR
+                    # speckle / motion blur) instead of stutter-stopping — the
+                    # stop-go is what wrecked the forward tracking. Straight =
+                    # toward where the aligned tag was (tag 1), never sideways
+                    # into an outer tag. Abort only if it stays lost too long.
+                    lost_frames += 1
+                    if lost_frames > self.visual_lost_max_frames:
+                        self._publish_cmd_vel(0.0, 0.0)
+                        self.get_logger().error(
+                            '   tag 1 lost too long in final approach — aborting')
+                        return False
+                    omega = 0.0   # fall through to the normal v taper + publish
 
             omega = max(-self.drive_yaw_max_omega,
                         min(self.drive_yaw_max_omega, omega))
-            v = self.drive_speed
+            # Actuation floor: the motor cannot turn below min_turn_omega. Sigma-delta
+            # PWM (omega_pwm) turns a sub-floor correction into a gentle pulsed turn
+            # instead of the ±0.15 hard-snap limit cycle; a small correction pulses
+            # rarely → drives essentially straight. Live-tunable (omega_pwm on/off).
+            omega = self._floor_omega(
+                omega, period, bool(self.get_parameter('omega_pwm').value))
+            v = drive_speed
             taper = 2.0 * self.docking_distance
             if depth < taper:
-                v = max(0.03, self.drive_speed * depth / taper)
+                # Floor the taper at the 0.05 m/s clean stick-slip floor.
+                # Measured (scripts/min_velocity_sweep.py, 2026-07-02): 0.02
+                # stalls, 0.03 judders (a-coups), 0.04 reliable, 0.05 is the
+                # lowest clean speed. The old 0.03 floor sat in the judder band.
+                v = max(0.05, drive_speed * depth / taper)
 
+            # DEBUG (throttled ~2 Hz): which regime is actually driving Phase 5.
+            now_dbg = time.time()
+            if now_dbg - getattr(self, '_p5_dbg', 0.0) > 0.5:
+                self._p5_dbg = now_dbg
+                branch = ('FAR-cam' if est_base is not None
+                          else ('FAR-map' if (not use_cam and pose is not None
+                                              and depth > freeze) else 'NEAR'))
+                norm_s = (f'{math.degrees(bnorm_filt):+.1f}'
+                          if bnorm_filt is not None else '  n/a')
+                self.get_logger().info(
+                    f'   [P5] depth={depth:.2f} {branch} norm={norm_s}° '
+                    f'omega={omega:+.2f} v={v:.2f} '
+                    f'c1={"Y" if (c1cam is not None) else "n"} '
+                    f'base={"Y" if (est_base is not None) else "n"} lost={lost_frames}')
             self._publish_cmd_vel(v, omega)
             self._publish_line_markers(cx, cy, normal_yaw)
             self._publish_gz_line_marker(cx, cy, normal_yaw)
@@ -806,6 +1148,83 @@ class DockTrigger(Node):
             return None
         rx, ry, _ = pose
         return self._dock_pose_from_tags(p0, p1, p2, rx, ry)
+
+    def _estimate_dock_base_once(self):
+        """One-shot dock estimate (cx, cy, normal_yaw) in the ROBOT frame
+        (base_link). Carries NO map (AMCL) or odometry error — the axis is
+        expressed relative to the robot, which sits at the origin facing +x.
+
+        Robust to a single outer-tag dropout: with BOTH outer tags it uses their
+        full 52 cm baseline (cleanest normal); with the CENTRE tag + ONE outer it
+        falls back to the half-baseline (centre→outer, collinear with the full tag
+        row) so the perpendicular alignment keeps running when id0 or id2 flickers
+        (the centre tag id1 is the reliably visible one). Returns None only if the
+        centre tag AND both outers are gone. This dropout tolerance is what the
+        earlier version lacked: requiring both outers made est_base None whenever
+        an outer tag dropped, silently reverting the approach to bearing-only
+        (which does not align perpendicular → 'not aligned, lost the tag')."""
+        p0 = self._lookup_tag_base('charging_dock_tag_0')
+        p1 = self._lookup_tag_base('charging_dock_tag_1')
+        p2 = self._lookup_tag_base('charging_dock_tag_2')
+        # Robot is at the origin of base_link → rx = ry = 0.
+        if p0 is not None and p2 is not None:
+            return self._dock_pose_from_tags(p0, p1, p2, 0.0, 0.0)
+        if p1 is None:
+            return None
+        if p2 is not None:
+            return self._dock_pose_from_two(p1, p2)
+        if p0 is not None:
+            return self._dock_pose_from_two(p1, p0)
+        return None
+
+    def _dock_pose_from_two(self, c, o):
+        """Dock pose (cx, cy, normal_yaw) from the CENTRE tag `c` + ONE outer tag
+        `o` (both (x, y) in base_link). Dock centre = the centre tag; the normal is
+        perpendicular to the centre→outer line (collinear with the full tag row),
+        disambiguated toward the robot at the origin. Half-baseline → noisier than
+        the two-outer estimate, but keeps the alignment alive through a dropout."""
+        dx, dy = o[0] - c[0], o[1] - c[1]
+        L = math.hypot(dx, dy)
+        if L < 1e-6:
+            return None
+        nx, ny = -dy / L, dx / L
+        if nx * (0.0 - c[0]) + ny * (0.0 - c[1]) < 0.0:
+            nx, ny = -nx, -ny
+        return c[0], c[1], math.atan2(-ny, -nx)
+
+    def _floor_omega(self, desired, period, pwm):
+        """Map a desired yaw rate to what the geared BLDC can actually execute.
+
+        The motor cannot turn below min_turn_omega (~0.15 rad/s stick-slip). A
+        plain floor snaps EVERY small correction up to ±min_turn_omega → a ±0.15
+        rad/s limit cycle (left-right hunting) around the line. With pwm=True we
+        sigma-delta modulate instead: above the floor the value passes through;
+        below it we emit ±min_turn_omega pulses at a duty cycle whose TIME AVERAGE
+        equals `desired`, so the effective turn rate is gentle and continuous. A
+        tiny |desired| accumulates slowly → pulses rarely → the robot drives
+        essentially straight (the 'straight when aligned' behaviour, for free)."""
+        accum = getattr(self, '_omega_accum', 0.0)
+        if abs(desired) < self.turn_deadband:
+            self._omega_accum = 0.0
+            return 0.0
+        if not pwm:                                   # legacy hard floor
+            if abs(desired) < self.min_turn_omega:
+                return math.copysign(self.min_turn_omega, desired)
+            return desired
+        if abs(desired) >= self.min_turn_omega:       # above floor: pass through
+            self._omega_accum = 0.0
+            return desired
+        # sub-floor: first-order sigma-delta to {−floor, 0, +floor}.
+        step = self.min_turn_omega * period
+        accum += desired * period
+        if accum >= step:
+            self._omega_accum = accum - step
+            return self.min_turn_omega
+        if accum <= -step:
+            self._omega_accum = accum + step
+            return -self.min_turn_omega
+        self._omega_accum = accum
+        return 0.0
 
     # ──────────────────────────────────────────────────────────────────────
     # Undock sequence
@@ -905,6 +1324,7 @@ class DockTrigger(Node):
         If only one tag is visible we steer toward it to bring the other into
         view; if neither is visible we rotate open-loop.
         """
+        self.scan_rotation_speed = float(self.get_parameter('scan_rotation_speed').value)
         period = 1.0 / self.drive_rate_hz
         timeout_s = 2.0 * math.pi / max(0.05, self.scan_rotation_speed) + 15.0
         deadline = time.time() + timeout_s
@@ -1128,6 +1548,11 @@ class DockTrigger(Node):
             stable_count = 0
             omega = self.spin_kp * err
             omega = max(-self.spin_max_omega, min(self.spin_max_omega, omega))
+            # Stiction floor: below spin_min_omega a spin-in-place never breaks
+            # static friction (judders without turning). We are past the tolerance
+            # band here (err ≥ spin_yaw_tolerance), so snap up to actually rotate.
+            if abs(omega) < self.spin_min_omega:
+                omega = math.copysign(self.spin_min_omega, omega)
             self._publish_cmd_vel(0.0, omega)
             time.sleep(period)
 
@@ -1152,7 +1577,7 @@ class DockTrigger(Node):
             # obstacle_forward_distance, stop, wait for it to clear, then
             # resume. If still blocked after obstacle_wait_timeout, abort.
             if not self._wait_for_path_clear(
-                0.0, self.obstacle_forward_distance,
+                self.obstacle_scan_forward_angle, self.obstacle_forward_distance,
                 self.obstacle_wait_timeout, 'forward drive'
             ):
                 self._publish_cmd_vel(0.0, 0.0)
@@ -1178,12 +1603,19 @@ class DockTrigger(Node):
             yaw_err = normalize_angle(target_yaw - ryaw)
             omega = self.drive_yaw_kp * yaw_err
             omega = max(-self.drive_yaw_max_omega, min(self.drive_yaw_max_omega, omega))
+            # Rotation stiction floor (see min_turn_omega): sub-0.15 rad/s
+            # corrections stick-slip, so snap small ones up and zero the deadband.
+            if abs(omega) < self.turn_deadband:
+                omega = 0.0
+            elif abs(omega) < self.min_turn_omega:
+                omega = math.copysign(self.min_turn_omega, omega)
 
             # Taper near goal
             taper = 5.0 * position_tolerance
             v = self.drive_speed
             if distance < taper:
-                v = max(0.03, self.drive_speed * (distance / taper))
+                # Floor at the 0.05 m/s clean stick-slip floor (measured).
+                v = max(0.05, self.drive_speed * (distance / taper))
             # If yaw way off, slow down to rotate first
             if abs(yaw_err) > 0.3:
                 v *= 0.3
@@ -1442,19 +1874,32 @@ class DockTrigger(Node):
         finally:
             self._gz_marker_inflight = False
 
-    def lookup_robot_pose(self):
+    def lookup_robot_pose(self, timeout_sec=1.0, quiet=False):
         try:
             t = self.tf_buffer.lookup_transform(
                 'map', 'base_link', rclpy.time.Time(),
-                timeout=Duration(seconds=1.0)
+                timeout=Duration(seconds=timeout_sec)
             )
         except Exception as e:
-            self.get_logger().warn(f'TF lookup failed: {e}')
+            if not quiet:
+                self.get_logger().warn(f'TF lookup failed: {e}')
             return None
         x = t.transform.translation.x
         y = t.transform.translation.y
         yaw = quat_to_yaw(t.transform.rotation)
         return x, y, yaw
+
+    def _lookup_odom_xy(self):
+        """odom->base_link translation (x, y). Always live (wheel+IMU EKF), so
+        LiDAR-independent — used to dead-reckon the last blind centimetres of the
+        approach once the tag leaves the FOV and the LiDAR (hence map) is off."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'odom', 'base_link', rclpy.time.Time(),
+                timeout=Duration(seconds=0.1))
+        except Exception:
+            return None
+        return t.transform.translation.x, t.transform.translation.y
 
     # ── Multi-tag perception (3 tags: id0/id2 outer, id1 centre) ──────────
     def _lookup_tag_cam(self, frame):
@@ -1472,6 +1917,23 @@ class DockTrigger(Node):
             return None
         return (t.transform.translation.x, t.transform.translation.y,
                 t.transform.translation.z)
+
+    def _lookup_tag_base(self, frame):
+        """(x, y) of `frame` in base_link (x forward, y left), or None if the TF
+        is missing/stale. base_link←camera_optical_frame is a STATIC transform and
+        camera←tag comes straight from AprilTag, so this is the tag position
+        RELATIVE TO THE ROBOT with no map (AMCL) and no odometry in the chain."""
+        try:
+            t = self.tf_buffer.lookup_transform(
+                'base_link', frame, rclpy.time.Time(),
+                timeout=Duration(seconds=0.1))
+        except Exception:
+            return None
+        age = (self.get_clock().now()
+               - rclpy.time.Time.from_msg(t.header.stamp)).nanoseconds * 1e-9
+        if age > self.detection_max_age:
+            return None
+        return (t.transform.translation.x, t.transform.translation.y)
 
     def _lookup_tag_map(self, frame):
         """(x, y) of `frame` in the map frame, or None if missing/stale."""
@@ -1510,16 +1972,33 @@ class DockTrigger(Node):
                 return c
         return None
 
-    def _send_action_blocking(self, client, goal) -> bool:
+    def _send_action_blocking(self, client, goal, accept_timeout: float = 10.0,
+                              result_timeout: float = 120.0) -> bool:
+        # Bounded waits: without a deadline a never-returning action (Nav2 stuck, lifecycle
+        # inactive, BT that never finishes) would block the sequence forever, leaving busy=True
+        # permanently so the node ignores every trigger/undock/goal until killed.
         send_future = client.send_goal_async(goal)
+        deadline = time.monotonic() + accept_timeout
         while not send_future.done():
+            if time.monotonic() > deadline:
+                self.get_logger().error('Goal acceptance timed out')
+                return False
             time.sleep(0.05)
         gh = send_future.result()
         if gh is None or not gh.accepted:
             self.get_logger().error('Goal rejected')
             return False
         result_future = gh.get_result_async()
+        deadline = time.monotonic() + result_timeout
         while not result_future.done():
+            if time.monotonic() > deadline:
+                self.get_logger().error(
+                    f'Action result timed out after {result_timeout}s; cancelling')
+                try:
+                    gh.cancel_goal_async()
+                except Exception:
+                    pass
+                return False
             time.sleep(0.05)
         result = result_future.result()
         if result is None:

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -1036,18 +1036,26 @@ class DockTrigger(Node):
                     carried_norm = bnorm_filt
                     carried_odom_yaw = self._lookup_odom_yaw()
                 else:
-                    # depth <= freeze: FROZEN normal (2026-07-07, Lesson 28 —
-                    # "the optimal gain in the near-field is zero"). bnorm_filt is
-                    # NOT updated anymore, no matter how many more tier-1 frames
-                    # arrive (even brief flickers back to 2+ tags near the dock,
-                    # where the wide baseline is noisiest, can no longer perturb
-                    # it) — this is what was still letting a small, intermittent
-                    # left-turn bias through even after the inverted weighting.
-                    # `lateral` stays FRESH every loop below (translation is more
-                    # reliable close up than orientation), only the heading
-                    # reference is locked. carried_norm/odom_yaw are correspondingly
-                    # NOT refreshed here — bnorm_filt no longer changes, so the
-                    # existing carried snapshot is already correct and stays valid.
+                    # depth <= freeze: FROZEN normal reference (2026-07-07, Lesson
+                    # 28 — "the optimal gain in the near-field is zero"). The
+                    # world-referenced normal captured at the freeze moment
+                    # (carried_norm/carried_odom_yaw, last set while depth > freeze)
+                    # is NOT held as a stale base_link-frame value — base_link
+                    # rotates WITH the robot, so a value frozen in that frame goes
+                    # wrong the moment the robot turns after the freeze (bug found
+                    # 2026-07-07: "au début c'est ok mais ensuite c'est pas bon").
+                    # Instead, re-derive bnorm_filt from the carried snapshot every
+                    # loop via the odom yaw delta — the exact same mechanism tier
+                    # 2's ref_yaw already uses. carried_norm/carried_odom_yaw
+                    # themselves are NOT refreshed here (they stay at their
+                    # freeze-moment values; only the current-frame projection of
+                    # them changes as the robot turns).
+                    odom_yaw_now = self._lookup_odom_yaw()
+                    if (carried_norm is not None and carried_odom_yaw is not None
+                            and odom_yaw_now is not None):
+                        bnorm_filt = normalize_angle(
+                            carried_norm - (odom_yaw_now - carried_odom_yaw))
+                    # else: odom briefly unavailable — keep last bnorm_filt.
                     blat_filt = lateral
                 desired_yaw = normalize_angle(
                     bnorm_filt - math.atan2(blat_filt, lookahead))

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -997,14 +997,17 @@ class DockTrigger(Node):
                 # Temporal EMA on the normal (byaw) + lateral, because WHILE MOVING
                 # a single frame jitters (vibration, blur, changing view angle).
                 # Weight SHRINKS as the robot gets closer (∝ depth/predock_distance,
-                # capped 0.6, floored 0.05) — 2026-07-07: the wide 2-outer-tag
+                # capped 0.20, floored 0.05) — 2026-07-07: the wide 2-outer-tag
                 # baseline degrades close up (corners hug the FOV edge, per
                 # docs/12_lessons_learned.md Lesson 28), so most of the trust should
                 # accumulate FAR/MID field, while it's still advancing, not right at
-                # the end. A floor (not 0) keeps a real persistent drift adapting
-                # slowly rather than fully freezing. A frame jumping >
-                # axis_spike_reject is dropped regardless.
-                a_n = max(0.05, min(0.6, self.axis_filter_alpha
+                # the end. Cap lowered from 0.6 -> 0.20 after real-hardware feedback
+                # that the line still changed too much mid-course even far away
+                # ("qu'elle change qu'un petit peu à mi-course") — a heavy, stable
+                # average throughout, not just near the dock. A floor (not 0) keeps
+                # a real persistent drift adapting slowly rather than fully
+                # freezing. A frame jumping > axis_spike_reject is dropped regardless.
+                a_n = max(0.05, min(0.20, self.axis_filter_alpha
                           * (depth / self.predock_distance)))
                 spike = float(self.get_parameter('axis_spike_reject').value)
                 if bnorm_filt is None:

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -996,11 +996,16 @@ class DockTrigger(Node):
                 lateral = bcx * math.sin(byaw) - bcy * math.cos(byaw)
                 # Temporal EMA on the normal (byaw) + lateral, because WHILE MOVING
                 # a single frame jitters (vibration, blur, changing view angle).
-                # Weight GROWS as the robot advances (∝ predock_distance/depth,
-                # capped 0.6), so nearer, more accurate frames dominate the far
-                # early ones. A frame jumping > axis_spike_reject is dropped.
-                a_n = min(0.6, self.axis_filter_alpha
-                          * (self.predock_distance / max(depth, 0.4)))
+                # Weight SHRINKS as the robot gets closer (∝ depth/predock_distance,
+                # capped 0.6, floored 0.05) — 2026-07-07: the wide 2-outer-tag
+                # baseline degrades close up (corners hug the FOV edge, per
+                # docs/12_lessons_learned.md Lesson 28), so most of the trust should
+                # accumulate FAR/MID field, while it's still advancing, not right at
+                # the end. A floor (not 0) keeps a real persistent drift adapting
+                # slowly rather than fully freezing. A frame jumping >
+                # axis_spike_reject is dropped regardless.
+                a_n = max(0.05, min(0.6, self.axis_filter_alpha
+                          * (depth / self.predock_distance)))
                 spike = float(self.get_parameter('axis_spike_reject').value)
                 if bnorm_filt is None:
                     bnorm_filt, blat_filt = byaw, lateral
@@ -1084,7 +1089,13 @@ class DockTrigger(Node):
                     spike2 = 0.15   # m — generous single-frame lateral jump reject
                     if dev2 <= spike2:
                         stability2 = max(0.15, 1.0 - dev2 / spike2)
-                        a2 = 0.3 * stability2
+                        # Same "weight shrinks closer in" idea as tier 1's a_n, scaled
+                        # to tier 2's own window (freeze_axis_distance -> docking_distance,
+                        # already a close-range window, so the taper is gentler than
+                        # tier 1's but still favours the earlier, less noisy tier-2 frames.
+                        depth_span = max(freeze - self.docking_distance, 0.05)
+                        depth_scale2 = max(0.15, min(1.0, (depth - self.docking_distance) / depth_span))
+                        a2 = 0.3 * stability2 * depth_scale2
                         lateral_t2_filt = (1.0 - a2) * lateral_t2_filt + a2 * lateral_raw
                     # else: spike — keep the last filtered lateral this frame
                 lateral = lateral_t2_filt

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -216,9 +216,18 @@ class DockTrigger(Node):
         # False: legacy hard floor. Live-tunable.
         self.declare_parameter('omega_pwm', True)
         # Stop the LiDAR during the NEAR visual approach (its IR dot can drop tag
-        # detections). OFF by default: on this unit stopping the motor ALSO kills
-        # the AprilTag detection within ~1 s (rplidar + apriltag share a component
-        # container — the motor stop disrupts it), so we keep the LiDAR on.
+        # detections — its ~5-6Hz spin period roughly matches the tag-detection
+        # flicker measured near contact, 2026-07-07 docking audit). OFF by default:
+        # a PRIOR observation was that stopping the motor also killed AprilTag
+        # detection within ~1s. That was attributed to apriltag and rplidar sharing
+        # a component container, but this has been VERIFIED FALSE (2026-07-07):
+        # apriltag runs standalone (docking_real.launch.py -> apriltag.launch.yml)
+        # and rplidar_composition runs as its own separate process
+        # (openamrobot_drivers/drivers.launch.py) — they have never shared a
+        # container. The real cause of the earlier observation (if it reproduces)
+        # is unconfirmed (USB bus/power contention on motor toggle? CPU spike?
+        # stale observation?) — worth re-testing on hardware before flipping this
+        # default; see the docking-improvement plan for the A/B test procedure.
         self.declare_parameter('stop_lidar_in_approach', False)
 
         # Initial tag-search scan. After Nav2 reaches the staging zone the

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -1153,23 +1153,28 @@ class DockTrigger(Node):
                 # lowest clean speed. The old 0.03 floor sat in the judder band.
                 v = max(0.05, drive_speed * depth / taper)
 
-            # DEBUG (throttled ~2 Hz): which tier is actually driving the approach.
+            # DEBUG (throttled ~2 Hz, clearer wording 2026-07-07): which tier is
+            # actually driving the approach, and whether the normal is frozen.
             now_dbg = time.time()
             if now_dbg - getattr(self, '_p5_dbg', 0.0) > 0.5:
                 self._p5_dbg = now_dbg
-                tier = ('T1-axis' if est_base is not None
-                        else ('T-legacy-map' if (not use_cam and pose is not None
-                                                 and depth > freeze)
-                              else ('T2-centre' if c1cam is not None else 'T3-BLIND')))
-                norm_s = (f'{math.degrees(bnorm_filt):+.1f}'
-                          if bnorm_filt is not None else '  n/a')
+                if est_base is not None:
+                    tier = 'TIER1 (2+ tags)'
+                elif not use_cam and pose is not None and depth > freeze:
+                    tier = 'LEGACY (map-frame)'
+                elif c1cam is not None:
+                    tier = 'TIER2 (centre tag only)'
+                else:
+                    tier = 'TIER3 (BLIND, no tags)'
+                frozen_s = 'FROZEN' if depth <= freeze else 'live'
+                norm_s = (f'{math.degrees(bnorm_filt):+.1f}deg'
+                          if bnorm_filt is not None else 'n/a')
                 self.get_logger().info(
-                    f'   [P5] depth={depth:.2f} {tier} norm={norm_s}° '
-                    f'omega={omega:+.2f} v={v:.2f} '
-                    f'c1={"Y" if (c1cam is not None) else "n"} '
-                    f'base={"Y" if (est_base is not None) else "n"} lost={lost_frames}')
+                    f'   [DOCKING] depth={depth:.2f}m  {tier}  normal={frozen_s} ({norm_s})  '
+                    f'omega={omega:+.2f}rad/s  v={v:.2f}m/s  '
+                    f'tags_visible={"yes" if c1cam is not None else "no"}  '
+                    f'blind_frames={lost_frames}')
             self._publish_cmd_vel(v, omega)
-            self._publish_line_markers(cx, cy, normal_yaw)
             self._publish_gz_line_marker(cx, cy, normal_yaw)
             time.sleep(period)
 
@@ -1808,72 +1813,22 @@ class DockTrigger(Node):
         msg.angular.z = float(omega)
         self.cmd_vel_pub.publish(msg)
 
-    def _publish_line_markers(self, cx: float, cy: float, perp_yaw: float):
-        """Publish the perpendicular approach line and the dock centre as RViz
-        markers in the map frame. See docs/13_perception_and_line.md.
-        """
-        if not self.publish_debug_markers:
-            return
-        now = self.get_clock().now().to_msg()
-        dirx, diry = math.cos(perp_yaw), math.sin(perp_yaw)
-        arr = MarkerArray()
-
-        # Green line: the perpendicular approach axis through the dock centre.
-        # perp_yaw points from the robot toward the dock, so the robot side of
-        # the line is at centre − dir; draw from there to just past the dock.
-        line = Marker()
-        line.header.frame_id = 'map'
-        line.header.stamp = now
-        line.ns = 'docking_line'
-        line.id = 0
-        line.type = Marker.LINE_STRIP
-        line.action = Marker.ADD
-        line.scale.x = 0.03
-        line.color.g = 1.0
-        line.color.a = 1.0
-        line.pose.orientation.w = 1.0
-        line.points = [
-            Point(x=cx - 4.0 * dirx, y=cy - 4.0 * diry, z=0.15),
-            Point(x=cx + 0.3 * dirx, y=cy + 0.3 * diry, z=0.15),
-        ]
-        arr.markers.append(line)
-
-        # Red sphere: the dock centre.
-        tag = Marker()
-        tag.header.frame_id = 'map'
-        tag.header.stamp = now
-        tag.ns = 'docking_tag'
-        tag.id = 1
-        tag.type = Marker.SPHERE
-        tag.action = Marker.ADD
-        tag.pose.position.x = cx
-        tag.pose.position.y = cy
-        tag.pose.position.z = 0.30
-        tag.pose.orientation.w = 1.0
-        tag.scale.x = tag.scale.y = tag.scale.z = 0.12
-        tag.color.r = 1.0
-        tag.color.a = 1.0
-        arr.markers.append(tag)
-
-        self.marker_pub.publish(arr)
-
     def _publish_base_link_normal_marker(self, normal_yaw: float, lateral: float, label: str):
-        """Publish the LIVE dock-normal estimate actually driving the controller,
+        """Publish the ONE live dock-normal line actually driving the controller,
         as an arrow in base_link frame (robot always has this frame, so it works
-        during camera-frame FAR and NEAR alike, unlike _publish_line_markers'
-        map-frame cx/cy/normal_yaw — which, on the real robot
-        (use_camera_frame_normal:=true), are the STALE Phase-4 estimate, never
-        updated by the live bnorm_filt EMA that's actually steering the robot.
-
-        Added 2026-07-07 after a real-robot test where the final heading was
-        wrong despite converging onto the line ("sur la normale mais pas la
-        bonne orientation") — this lets the operator watch in RViz whether the
-        normal estimate is stable (well-averaged) or noisy in real time, which
-        the old map-frame marker could never show for the camera-frame path.
+        across every tier). There used to ALSO be a map-frame RViz line
+        (_publish_line_markers, removed 2026-07-07) fed by cx/cy/normal_yaw —
+        which, on the real robot (use_camera_frame_normal:=true), was a STALE
+        Phase-4 snapshot, never updated by the live estimate that actually
+        steers the robot. That stale marker + this one being cyan gave two
+        conflicting lines in RViz. Now there is only this one: green.
 
         normal_yaw: dock normal, base_link frame (0 = robot's current forward).
         lateral: signed lateral offset (m) at the current lookahead, for the dot.
-        label: 'FAR-cam avg' or 'NEAR carried', kept as the marker ns for clarity.
+        label: 'axis (2+ tags)' or 'centre-only carried' — informational only,
+        NOT part of the marker namespace (a namespace-per-label bug briefly
+        caused two simultaneous arrows when the tier flickered; fixed to a
+        single constant namespace so a newer publish always replaces the old).
         """
         if not self.publish_debug_markers:
             return
@@ -1883,7 +1838,7 @@ class DockTrigger(Node):
         arrow = Marker()
         arrow.header.frame_id = 'base_link'
         arrow.header.stamp = now
-        arrow.ns = 'dock_normal_live'
+        arrow.ns = 'docking_line'
         arrow.id = 0
         arrow.type = Marker.ARROW
         arrow.action = Marker.ADD
@@ -1894,18 +1849,17 @@ class DockTrigger(Node):
         arrow.scale.x = 0.04   # shaft diameter
         arrow.scale.y = 0.08   # head diameter
         arrow.scale.z = 0.12   # head length
-        arrow.color.b = 1.0
-        arrow.color.g = 1.0    # cyan — distinct from the green map-frame line
+        arrow.color.g = 1.0    # green — the one and only docking line
         arrow.color.a = 1.0
         arrow.pose.orientation.w = 1.0
         arr.markers.append(arrow)
 
-        # Small magenta dot at the lateral offset, lookahead metres ahead —
-        # the point the pure-pursuit law is actually steering toward.
+        # Small red dot at the lateral offset, lookahead metres ahead — the
+        # point the pure-pursuit law is actually steering toward.
         dot = Marker()
         dot.header.frame_id = 'base_link'
         dot.header.stamp = now
-        dot.ns = 'dock_normal_live'
+        dot.ns = 'docking_line'
         dot.id = 1
         dot.type = Marker.SPHERE
         dot.action = Marker.ADD
@@ -1915,7 +1869,6 @@ class DockTrigger(Node):
         dot.pose.orientation.w = 1.0
         dot.scale.x = dot.scale.y = dot.scale.z = 0.06
         dot.color.r = 1.0
-        dot.color.b = 1.0
         dot.color.a = 1.0
         arr.markers.append(dot)
 

--- a/ros2/src/openamrobot_docking/scripts/dock_trigger.py
+++ b/ros2/src/openamrobot_docking/scripts/dock_trigger.py
@@ -1009,7 +1009,10 @@ class DockTrigger(Node):
                 spike = float(self.get_parameter('axis_spike_reject').value)
                 if bnorm_filt is None:
                     bnorm_filt, blat_filt = byaw, lateral
-                else:
+                    carried_norm = bnorm_filt
+                    carried_odom_yaw = self._lookup_odom_yaw()
+                elif depth > freeze:
+                    # Still far/mid field: keep refining the normal as usual.
                     dev = abs(normalize_angle(byaw - bnorm_filt))
                     if dev <= spike:
                         # Stability weighting: a sample close to the CURRENT running
@@ -1027,16 +1030,30 @@ class DockTrigger(Node):
                             bnorm_filt + a_eff * normalize_angle(byaw - bnorm_filt))
                         blat_filt = (1.0 - a_eff) * blat_filt + a_eff * lateral
                     # else: spike — keep the last filtered normal this frame
+                    # Keep the carried snapshot fresh while still far/mid field —
+                    # always the LATEST good axis, so tier 2 (if it kicks in) starts
+                    # from the best data available.
+                    carried_norm = bnorm_filt
+                    carried_odom_yaw = self._lookup_odom_yaw()
+                else:
+                    # depth <= freeze: FROZEN normal (2026-07-07, Lesson 28 —
+                    # "the optimal gain in the near-field is zero"). bnorm_filt is
+                    # NOT updated anymore, no matter how many more tier-1 frames
+                    # arrive (even brief flickers back to 2+ tags near the dock,
+                    # where the wide baseline is noisiest, can no longer perturb
+                    # it) — this is what was still letting a small, intermittent
+                    # left-turn bias through even after the inverted weighting.
+                    # `lateral` stays FRESH every loop below (translation is more
+                    # reliable close up than orientation), only the heading
+                    # reference is locked. carried_norm/odom_yaw are correspondingly
+                    # NOT refreshed here — bnorm_filt no longer changes, so the
+                    # existing carried snapshot is already correct and stays valid.
+                    blat_filt = lateral
                 desired_yaw = normalize_angle(
                     bnorm_filt - math.atan2(blat_filt, lookahead))
                 omega = line_kp * desired_yaw
                 lost_frames = 0
                 lateral_t2_filt = None   # reset tier 2's smoother — see tier 2 below
-                # Keep the carried snapshot fresh for whenever tier 1 drops out
-                # (outer tags leave the FOV) — always the LATEST good axis, not a
-                # one-time freeze, so tier 2 picks up from the best data available.
-                carried_norm = bnorm_filt
-                carried_odom_yaw = self._lookup_odom_yaw()
                 self._publish_base_link_normal_marker(bnorm_filt, blat_filt, 'axis (2+ tags)')
             elif (not use_cam) and pose is not None and depth > freeze:
                 rx, ry, ryaw = pose


### PR DESCRIPTION
The AprilTag docking pipeline on the real robot. Last of the stacked set — rebased on
`main` after #21 (bring-up) and #22 (docs); merges cleanly. Code-focused (the audited
docking docs already landed in #22).

## What this adds
- **3-tag bundle (36h11) + geometric dock normal**, and an **on-demand AprilTag gate**
  so vision CPU is only spent during a dock.
- **Unified odom-frame approach line**: the dock reference line lives permanently in the
  `odom` frame, refined by lag-correct in-odom tag lookups — no `base_link↔odom` tier
  switch. Fixes the reference line swinging with the robot and the near-dock oscillation.
  `unified_odom_line` param (default true, live-tunable).
- **LiDAR-controlled final stop** (`stop_lidar_distance` 0.13 m; camera depth is a
  failsafe); forward obstacle guard **off by default** (the dock trips it), live-tunable;
  calmed pure-pursuit gains; `final_push_speed` to clear the dock lip on a low battery.
- During the maneuver: **AMCL laser correction kept + Nav2 collision_monitor paused**
  (only after Phase 1, so Phase 1's Nav2 goal still reaches the base); undock reverse
  **measured in odom** (immune to the AMCL relocalise jump) + a rough ~180° spin.
- **`log_splitter`** — splits `/rosout` into per-node `/logs/<node>` topics for focused
  debugging.
- `docs/15_legacy_near_approach.md` — documents the pre-2026-07-07 NEAR corrector as the
  rollback reference.

⚠️ Reviewers: read this **commit by commit**, not the full diff (dock_trigger.py is a
large but scoped rework).
