### PR TITLE
fix(description): correct sim diff-drive wheel geometry to match the real robot

### DIFF
--- a/ros2/src/openamrobot_description/urdf/robot.sdf
+++ b/ros2/src/openamrobot_description/urdf/robot.sdf
@@ -626,8 +626,8 @@
     <plugin filename="gz-sim-diff-drive-system" name="gz::sim::systems::DiffDrive">
       <left_joint>left_wheel_joint</left_joint>
       <right_joint>right_wheel_joint</right_joint>
-      <wheel_separation>0.4075</wheel_separation>
-      <wheel_radius>0.046533</wheel_radius>
+      <wheel_separation>0.46</wheel_separation>
+      <wheel_radius>0.10</wheel_radius>
       <odom_publish_frequency>50</odom_publish_frequency>
       <topic>/cmd_vel</topic>
       <odom_topic>/odom</odom_topic>


### PR DESCRIPTION
Independent of the other PRs — touches only `openamrobot_description/urdf/robot.sdf`.

## The bug
The Gazebo diff-drive plugin used `wheel_radius 0.046533` / `wheel_separation 0.4075`.
Those are wrong: `0.046533` is the wheel **axle height (Z)** from the CAD-exported URDF,
not the wheel radius. The real robot (firmware, physically measured) is **wheel radius
0.10 m (Ø 0.2 m)** and **track 0.46 m**. The wrong values scaled sim odometry/kinematics
by ~2.15× vs the physical robot.

## The fix
`wheel_radius` → `0.10`, `wheel_separation` → `0.46`.

## ⚠️ Needs sim re-validation before merge
This rescales sim odometry by ~2.15×: the sim robot now moves at the correct commanded
speed, but the Nav2 / docking **sim** parameters were previously tuned against the wrong
scale. Please re-run a sim nav + docking pass and re-tune if needed before merging.

## Cosmetic follow-up (not in this PR)
The wheel visual/collision cylinder radius (`0.11`) and the wheel joint origin Z
(`0.046533`) in `robo_urdf.urdf.xacro` are still inconsistent with `0.10` and should be
aligned in a later change (needs a sim pose check).
